### PR TITLE
make it possible to use this workflow with > 64 repos

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -1,29 +1,17 @@
+# This workflow is triggered by the dispatch workflow.
+
 on:
-  pull_request:
-    branches: [ master ]
-    types: [ closed ] # IMPORTANT: check the merge status for every job: github.event.pull_request.merged == true
+  repository_dispatch:
+    types: [ copy-workflow ]
 
 jobs:
-  matrix:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    outputs:
-      targets: ${{ steps.set-matrix.outputs.targets }}
-    steps:
-      - uses: actions/checkout@v2
-      - id: set-matrix
-        run: |
-          TARGETS=$(jq -c . .github/workflows/config.json)
-          echo "::set-output name=targets::$TARGETS"
   copy:
-    if: github.event.pull_request.merged == true
-    needs: [ matrix ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        cfg: ${{ fromJson(needs.matrix.outputs.targets) }}
-        workflow: [ "autorebase", "automerge", "go-test", "go-check" ]
+        cfg: ${{ github.event.client_payload.targets }}
+        workflow: ${{ github.event.client_payload.workflows }}
     env:
       WORKFLOW_DIR: "workflow-repo"
       FILE: "${{ matrix.workflow }}.yml"
@@ -64,11 +52,10 @@ jobs:
       if: ${{ env.NEEDS_UPDATE == 1 }}
       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2
       with:
-        commit-message: "update ${{ env.FILE }}: ${{ github.event.pull_request.title }}"
-        title: "${{ matrix.workflow }}: ${{ github.event.pull_request.title }}"
+        commit-message: "update ${{ env.FILE }}: ${{ github.event.client_payload.github.event.pull_request.title }}"
+        title: "${{ matrix.workflow }}: ${{ github.event.client_payload.github.event.pull_request.title }}"
         body: |
-          Change introduced by ${{ github.event.pull_request.html_url }}.
-
+          Change introduced by ${{ github.event.client_payload.github.event.pull_request.html_url }}.
           ---
           You can trigger a rebase by commenting `@web3-bot rebase`.
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,42 @@
+# Trigger the execution of copy-workflow.yml, in batches of 5 repositories.
+# This workflow is needed since GitHub Actions limits the matrix size to 256 jobs.
+# We use one job per repository per file.
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ closed ] # IMPORTANT: check the merge status for every job: github.event.pull_request.merged == true
+
+env:
+  # We could use a higher number here. We use a small number just to make sure to create multiple batches.
+  MAX_REPOS_PER_WORKFLOW: 5
+  WORKFLOWS: '[ "autorebase", "automerge", "go-test", "go-check" ]' # a JSON array of the files to distribute
+
+jobs:
+  matrix:
+    if: github.event.pull_request.merged == true
+    name: Trigger copy workflows
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set-matrix.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: |
+          TARGETS=$(jq '. | _nwise(${{ env.MAX_REPOS_PER_WORKFLOW }})' .github/workflows/config.json | jq -sc '. | to_entries')
+          echo "::set-output name=targets::$TARGETS"
+  dispatch:
+    if: github.event.pull_request.merged == true
+    needs: [ matrix ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg: ${{ fromJson(needs.matrix.outputs.targets) }}
+    name: Start copy workflow (batch ${{ matrix.cfg.key }})
+    steps:
+      - uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4 # v1.1.3
+        with:
+          token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
+          event-type: copy-workflow
+          client-payload: '{ "github": ${{ toJson(github) }}, "workflows": ${{ env.WORKFLOWS }}, "targets": ${{ toJson(matrix.cfg.value) }} }'


### PR DESCRIPTION
## Problem

GitHub Actions limits the number of jobs in a matrix to 256. We create one job per repository and per file that we're copying. Therefore at the moment we're limited to 256/4 = 64 repositories.

## Solution

This PR uses the [repository dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch) function. In a nutshell, this feature allows us to emit a custom event named `copy-workflow`. We can then define another workflow that's triggered by this event.

### Details

The `dispatch.yml` workflow parses the `config.json` file (which contains a list of all participating repos). It batches the repositories into batches of 50: https://github.com/ipld/.github/blob/adb77431ecc3416bd1635e1f5bbcc640e41405f0/.github/workflows/dispatch.yml#L24-L25

For example, if we had 500 participating repositories, we'd end up with 10 batches of 50 repos. For every one of those batches, we then trigger a `copy-workflow` event. We pass both the list of repositories in this batch as well as the list of files to that workflow:
https://github.com/ipld/.github/blob/adb77431ecc3416bd1635e1f5bbcc640e41405f0/.github/workflows/dispatch.yml#L38-L42.

Each `copy-workflow` then creates a matrix running one job per target repository and file.

### Limitations

The dispatch workflow also uses a matrix, which limits us to 256 batches. Theoretically, the upper limit of repositories supported is therefore 256*256/(num files) = 16,384 (for 4 files). In practice, this limit will be a bit lower once we add a options to `config.json` to configure which files will be synced for a particular repository. Still, this should be plenty, considering that currently "only" have O(1000) repos.