### PR TITLE
only create a single PR per target repo

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -11,16 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ github.event.client_payload.targets }}
-        file: ${{ github.event.client_payload.files }}
     env:
       TEMPLATE_REPO_DIR: "template-repo"
       TEMPLATE_DIR: "templates"
-      FILE: "${{ matrix.file }}"
       NEEDS_UPDATE: 0
-      # We overwrite these values if this is the first deployment of this file.
-      COMMIT_MSG: "update ${{ matrix.file }}: ${{ github.event.client_payload.github_event.pull_request.title }}"
-      PR_TITLE: "${{ matrix.file }}: ${{ github.event.client_payload.github_event.pull_request.title }}"
-    name: Update ${{ matrix.file }} on ${{ matrix.cfg.target }}
+    name: Update ${{ matrix.cfg.target }}
     steps:
     - name: Checkout ${{ matrix.cfg.target }}
       uses: actions/checkout@v2
@@ -32,40 +27,49 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
-    - name: Add "DO NOT EDIT" header to ${{ env.FILE }}
+    - name: Create commits
       run: |
-        tmp=$(mktemp)
-        cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE > $tmp
-        mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE
-    - name: Check if an update to ${{ env.FILE }} is neccessary
-      run: |
-        if [[ ! -f "${{ env.FILE }}" ]]; then
-          echo "First deployment of this file."
-          echo 'COMMIT_MSG=add ${{ env.FILE }}' >> $GITHUB_ENV
-          echo 'PR_TITLE=add ${{ env.FILE }}' >> $GITHUB_ENV
-          echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
-          exit
-        fi
-        STATUS=$(cmp --silent $FILE $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE; echo $?)
-        if [[ $STATUS -ne 0 ]]; then
-          echo "Update needed."
-          echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
-        else
-          echo "Files indentical. Skipping."
-        fi
-    - name: Copy ${{ env.FILE }} to target repo
-      if: ${{ env.NEEDS_UPDATE == 1 }}
-      run: |
-        dir=$(dirname $FILE)
-        mkdir -p $dir
-        cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE $dir
+        git config user.name web3-bot
+        git config user.email "web3-bot@users.noreply.github.com"
+        for f in $(jq ".[]" <<< '${{ toJson(github.event.client_payload.files) }}' | xargs -n1); do 
+          echo -e "\nProcessing $f."
+          needs_update=false
+          # add DO NOT EDIT header
+          tmp=$(mktemp)
+          cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f > $tmp
+          mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f
+          # create commit, if necessary
+          commit_msg=""
+          if [[ ! -f "$f" ]]; then
+            echo "First deployment.\n"
+            commit_msg="add $f"
+            needs_update=true
+          else
+            status=$(cmp --silent $f $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f; echo $?)
+            if [[ $status -ne 0 ]]; then
+              echo "Update needed."
+              commit_msg="update $f"
+              needs_update=true
+            else
+              echo "File indentical. Skipping."
+              continue
+            fi
+          fi
+          if [ $needs_update = true ]; then
+            dir=$(dirname $f)
+            mkdir -p $dir
+            cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f $dir
+            git add $f
+            git commit -m "$commit_msg"
+            echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
+          fi
+        done
         rm -rf $TEMPLATE_REPO_DIR
     - name: Create Pull Request
       if: ${{ env.NEEDS_UPDATE == 1 }}
       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2
       with:
-        commit-message: ${{ env.COMMIT_MSG }}
-        title: ${{ env.PR_TITLE }}
+        title: "sync: ${{ github.event.client_payload.github_event.pull_request.title }}"
         body: |
           Change introduced by ${{ github.event.client_payload.github_event.pull_request.html_url }}.
           ---
@@ -73,5 +77,5 @@ jobs:
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
         committer: web3-bot <web3-bot@users.noreply.github.com>
         author: web3-bot <web3-bot@users.noreply.github.com>
-        branch: web3-bot/update-${{ matrix.file }}
+        branch: web3-bot/sync
         delete-branch: true

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -31,9 +31,8 @@ jobs:
       run: |
         git config user.name web3-bot
         git config user.email "web3-bot@users.noreply.github.com"
-        for f in $(jq ".[]" <<< '${{ toJson(github.event.client_payload.files) }}' | xargs -n1); do 
+        for f in $(jq -r ".[]" <<< '${{ toJson(github.event.client_payload.files) }}'); do 
           echo -e "\nProcessing $f."
-          needs_update=false
           # add DO NOT EDIT header
           tmp=$(mktemp)
           cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f > $tmp
@@ -43,26 +42,22 @@ jobs:
           if [[ ! -f "$f" ]]; then
             echo "First deployment.\n"
             commit_msg="add $f"
-            needs_update=true
           else
             status=$(cmp --silent $f $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f; echo $?)
             if [[ $status -ne 0 ]]; then
               echo "Update needed."
               commit_msg="update $f"
-              needs_update=true
             else
               echo "File indentical. Skipping."
               continue
             fi
           fi
-          if [ $needs_update = true ]; then
-            dir=$(dirname $f)
-            mkdir -p $dir
-            cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f $dir
-            git add $f
-            git commit -m "$commit_msg"
-            echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
-          fi
+          dir=$(dirname $f)
+          mkdir -p $dir
+          cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f $dir
+          git add $f
+          git commit -m "$commit_msg"
+          echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
         done
         rm -rf $TEMPLATE_REPO_DIR
     - name: Create Pull Request

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         cfg: ${{ github.event.client_payload.targets }}
         file: ${{ github.event.client_payload.files }}
     env:
-      TARGET_DIR: "target-repo"
+      TEMPLATE_REPO_DIR: "template-repo"
       TEMPLATE_DIR: "templates"
       FILE: "${{ matrix.file }}"
       NEEDS_UPDATE: 0
@@ -31,12 +31,12 @@ jobs:
     - name: Checkout template repository
       uses: actions/checkout@v2
       with:
-        path: ${{ env.TARGET_DIR }}
+        path: ${{ env.TEMPLATE_REPO_DIR }}
     - name: Add "DO NOT EDIT" header to ${{ env.FILE }}
       run: |
         tmp=$(mktemp)
-        cat $TARGET_DIR/$TEMPLATE_DIR/header.yml $TARGET_DIR/$TEMPLATE_DIR/$FILE > $tmp
-        mv $tmp $TARGET_DIR/$TEMPLATE_DIR/$FILE
+        cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE > $tmp
+        mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE
     - name: Check if an update to ${{ env.FILE }} is neccessary
       run: |
         if [[ ! -f "${{ env.FILE }}" ]]; then
@@ -46,7 +46,7 @@ jobs:
           echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
           exit
         fi
-        STATUS=$(cmp --silent $FILE $TARGET_DIR/$TEMPLATE_DIR/$FILE; echo $?)
+        STATUS=$(cmp --silent $FILE $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE; echo $?)
         if [[ $STATUS -ne 0 ]]; then
           echo "Update needed."
           echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
@@ -58,8 +58,8 @@ jobs:
       run: |
         dir=$(dirname $FILE)
         mkdir -p $dir
-        cp $TARGET_DIR/$TEMPLATE_DIR/$FILE $dir
-        rm -rf $TARGET_DIR
+        cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$FILE $dir
+        rm -rf $TEMPLATE_REPO_DIR
     - name: Create Pull Request
       if: ${{ env.NEEDS_UPDATE == 1 }}
       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2


### PR DESCRIPTION
In https://github.com/protocol/.github/issues/36#issuecomment-809463015, @mvdan suggested to only create a single PR per target repo, consisting of multiple commits, one for each file that was changed.

This will significantly reduce the noise of introducing this workflow to new repositories, as we're only opening a single PR instead of 4. It will also allow us to push changes to more repositories before triggering GitHub's abuse detection mechanism.