### PR TITLE
add the script used check the Go repo health

### DIFF
--- a/scripts/get-repos/index.js
+++ b/scripts/get-repos/index.js
@@ -1,6 +1,12 @@
 import {Octokit} from '@octokit/rest'
+import { Command } from 'commander/esm.mjs';
 
-const LANGUAGES = ["JavaScript", "Go"]
+const program = new Command();
+program.option('-l, --languages [lang...]', 'languages (e.g. JavaScript, Go)', ['JavaScript', 'Go'])
+program.parse(process.argv);
+const opts = program.opts();
+
+const LANGUAGES = opts.languages;
 const ORGS = ["ipfs", "ipfs-shipyard", "ipld", "libp2p", "multiformats"]
 
 const options = {}

--- a/scripts/get-repos/package-lock.json
+++ b/scripts/get-repos/package-lock.json
@@ -8,7 +8,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@octokit/rest": "^18.5.2"
+        "@octokit/rest": "^18.5.2",
+        "commander": "^8.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -135,6 +136,14 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/commander": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -293,6 +302,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "commander": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
     },
     "deprecation": {
       "version": "2.3.1",

--- a/scripts/get-repos/package.json
+++ b/scripts/get-repos/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^18.5.2"
+    "@octokit/rest": "^18.5.2",
+    "commander": "^8.0.0"
   }
 }

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+to_status() {
+  if [[ $1 == 0 ]]; then
+    printf "✅"
+    return
+  fi
+  printf "❌"
+}
+
+check_go_mod_tidy() {
+  if [[ ! -f go.mod || ! -f go.sum ]]; then
+    echo 1
+    return
+  fi
+  cp go.mod go.mod.orig
+  cp go.sum go.sum.orig
+  go mod tidy &> /dev/null
+  diff go.mod go.mod.orig > /dev/null
+  if [[ $? != 0 ]]; then
+    echo 1
+    return
+  fi
+  diff go.sum go.sum.orig > /dev/null
+  echo $?
+}
+
+check_go_fmt() {
+  out=$(gofmt -l . | xargs)
+  if [[ -z "$out" ]]; then
+    echo 0
+    return
+  fi
+  echo 1
+}
+
+for repo in $(node get-repos/index.js -l Go | jq -r '.[]'); do
+  tmp=$(mktemp -d)
+  pushd $tmp > /dev/null
+  git clone -q https://github.com/$repo .
+  if [[ ! -f .github/workflows/go-check.yml ]]; then # if the workflows aren't deployed yet
+    numcommits=$(git rev-list --count --since="Oct 1 2020" --all --no-merges)
+    pr=$(git branch -r --no-merged | grep -c web3-bot/sync)
+    if [[ $pr == 0 ]]; then # if there's no PR to add the workflows
+      gomodtidy=$(check_go_mod_tidy)
+      gofmt=$(check_go_fmt)
+      go test -failfast ./... &> /dev/null
+      gotest=$?
+      go test -failfast -race ./... &> /dev/null
+      gotestrace=$?
+      go vet ./... &> /dev/null
+      govet=$?
+      staticcheck ./... &> /dev/null
+      staticcheck=$?
+      echo "$repo $numcommits false $(to_status $gomodtidy) $(to_status $gofmt) $(to_status $gotest) $(to_status $gotestrace) $(to_status $govet) $(to_status $staticcheck)"
+    else
+      echo "$repo $numcommits true"
+    fi
+  fi
+  popd > /dev/null
+  rm -rf $tmp
+done
+


### PR DESCRIPTION
Depends on #145, as it used the `get-repos` script.

This is the script that was used to generate the [Go Repo Health](https://docs.google.com/spreadsheets/d/1Vwk-OUKXXNQkp4BkOoMndLylnJRW7a2c_mmvXu6jIj8/edit#gid=0) spreadsheet, now with an added column indicating if web3-bot already created a PR or not.