### PR TITLE
remove Travis and CircleCI configs on first deployment of test workflow

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -15,6 +15,7 @@ jobs:
       TEMPLATE_REPO_DIR: "template-repo"
       TEMPLATE_DIR: "templates"
       NEEDS_UPDATE: 0
+      INITIAL_TEST_DEPLOYMENT: 0
     name: Update ${{ matrix.cfg.target }}
     steps:
     - name: Checkout ${{ matrix.cfg.target }}
@@ -27,6 +28,27 @@ jobs:
       run: |
         git config user.name web3-bot
         git config user.email "web3-bot@users.noreply.github.com"
+    - name: is initial test workflow deployment
+      run: |
+        if [[ ! -f .github/workflows/go-test.yml ]]; then
+          echo "INITIAL_TEST_DEPLOYMENT=1" >> $GITHUB_ENV
+        fi
+    - name: remove Travis on initial deployment
+      if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
+      run: |
+        if [[ -f .travis.yml ]]; then
+          git rm .travis.yml
+          git commit -m "disable Travis"
+          echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
+        fi
+    - name: remove CircleCI on initial deployment
+      if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
+      run: |
+        if [[ -d .circleci ]]; then
+          git rm -r .circleci
+          git commit -m "disable CircleCI"
+          echo "NEEDS_UPDATE=1" >> $GITHUB_ENV
+        fi
     - name: run go mod tidy
       run: |
         go mod edit -go 1.15


### PR DESCRIPTION
As suggested by @aschmahmann, when we first deploy the `go-test` workflow to repositories, we should disable Travis and CircleCI. The copy workflow adds commits deleting `.travis.yml` and `.circleci/`, IF `.github/workflows/go-test.yml` doesn't exist yet (and thus will be added in the same PR).