### PR TITLE
run dispatch workflow when pushing to master

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -102,9 +102,10 @@ jobs:
       if: ${{ env.NEEDS_UPDATE == 1 }}
       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2
       with:
-        title: "sync: ${{ github.event.client_payload.github_event.pull_request.title }}"
+        title: "sync: update CI config files"
         body: |
-          Change introduced by ${{ github.event.client_payload.github_event.pull_request.html_url }}.
+          Syncing to commit ${{ github.event.client_payload.github_event.head_commit.url }}.
+          
           ---
           You can trigger a rebase by commenting `@web3-bot rebase`.
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -3,9 +3,8 @@
 # We use one job per repository per file.
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
-    types: [ closed ] # IMPORTANT: check the merge status for every job: github.event.pull_request.merged == true
 
 env:
   # We could use a higher number here. We use a small number just to make sure to create multiple batches.
@@ -14,7 +13,6 @@ env:
 
 jobs:
   matrix:
-    if: github.event.pull_request.merged == true
     name: Trigger copy workflows
     runs-on: ubuntu-latest
     outputs:
@@ -26,7 +24,6 @@ jobs:
           TARGETS=$(jq '. | _nwise(${{ env.MAX_REPOS_PER_WORKFLOW }})' .github/workflows/config.json | jq -sc '. | to_entries')
           echo "::set-output name=targets::$TARGETS"
   dispatch:
-    if: github.event.pull_request.merged == true
     needs: [ matrix ]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Fixes #49.

Our current logic is slightly wrong: We build the (last) commit of a PR, not the merge commit. We did this because it allows us easy access to the PR title, which GitHub doesn't give us for a push to master.
Furthermore, since we were building a PR, GitHub would only give us access to the repository's secrets if we weren't building from a fork.

This PR changes the logic: We now build every push on master. As master is branch-protected, this means we'll only build merge commits. We lose access to the PR title here, which is why I replaced the PR title with a generic "sync: update CI config files" (which @mvdan suggested anyway).

As a future improvement, we might be able to regain access to some of the information if we restrict the merge method to squashing, but I haven't tried this out yet.