### PR TITLE
make it possible to use different GitHub users per GitHub org

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         cfg: ${{ github.event.client_payload.targets }}
     env:
+      TARGET_REPO_DIR: "target-repo"
       TEMPLATE_REPO_DIR: "template-repo"
       TEMPLATE_DIR: "templates"
       NEEDS_UPDATE: 0
@@ -21,21 +22,24 @@ jobs:
     - name: Checkout ${{ matrix.cfg.target }}
       uses: actions/checkout@v2
       with:
+        path: {{ $env.TARGET_REPO_DIR }}
         repository: ${{ matrix.cfg.target }}
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
         persist-credentials: true
     - name: git config
       run: |
+        cd $TARGET_REPO_DIR
         git config user.name web3-bot
         git config user.email "web3-bot@users.noreply.github.com"
     - name: is initial test workflow deployment
       run: |
-        if [[ ! -f .github/workflows/go-test.yml ]]; then
+        if [[ ! -f $TARGET_REPO_DIR/.github/workflows/go-test.yml ]]; then
           echo "INITIAL_TEST_DEPLOYMENT=1" >> $GITHUB_ENV
         fi
     - name: remove Travis on initial deployment
       if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
       run: |
+        cd $TARGET_REPO_DIR
         if [[ -f .travis.yml ]]; then
           git rm .travis.yml
           git commit -m "disable Travis"
@@ -43,12 +47,14 @@ jobs:
     - name: remove CircleCI on initial deployment
       if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
       run: |
+        cd $TARGET_REPO_DIR
         if [[ -d .circleci ]]; then
           git rm -r .circleci
           git commit -m "disable CircleCI"
         fi
     - name: run go mod tidy
       run: |
+        cd $TARGET_REPO_DIR
         go mod edit -go 1.15
         go mod tidy
         if ! git diff --quiet; then
@@ -57,6 +63,7 @@ jobs:
         fi
     - name: gofmt
       run: |
+        cd $TARGET_REPO_DIR
         gofmt -s -w .
         if ! git diff --quiet; then
           git add .
@@ -76,11 +83,11 @@ jobs:
           mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f
           # create commit, if necessary
           commit_msg=""
-          if [[ ! -f "$f" ]]; then
+          if [[ ! -f "$TARGET_REPO_DIR/$f" ]]; then
             echo "First deployment.\n"
             commit_msg="add $f"
           else
-            status=$(cmp --silent $f $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f; echo $?)
+            status=$(cmp --silent $TARGET_REPO_DIR/$f $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f; echo $?)
             if [[ $status -ne 0 ]]; then
               echo "Update needed."
               commit_msg="update $f"
@@ -89,19 +96,23 @@ jobs:
               continue
             fi
           fi
-          dir=$(dirname $f)
+          dir="$TARGET_REPO_DIR/"$(dirname $f)
           mkdir -p $dir
           cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f $dir
+          pushd $TARGET_REPO_DIR > /dev/null
           git add $f
           git commit -m "$commit_msg"
+          popd > /dev/null
         done
-        rm -rf $TEMPLATE_REPO_DIR
     - name: Check if we need to create a PR
-      run: echo "NEEDS_UPDATE=$(git rev-list HEAD...origin/$(git rev-parse --abbrev-ref HEAD) --ignore-submodules --count)" >> $GITHUB_ENV
+      run: |
+        cd $TARGET_REPO_DIR
+        echo "NEEDS_UPDATE=$(git rev-list HEAD...origin/$(git rev-parse --abbrev-ref HEAD) --ignore-submodules --count)" >> $GITHUB_ENV
     - name: Create Pull Request
       if: ${{ env.NEEDS_UPDATE }}
       uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2
       with:
+        path: ${{ env.TARGET_REPO_DIR }}
         title: "sync: update CI config files"
         body: |
           Syncing to commit ${{ github.event.client_payload.github_event.head_commit.url }}.

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -17,6 +17,8 @@ jobs:
       TEMPLATE_DIR: "templates"
       NEEDS_UPDATE: 0
       INITIAL_TEST_DEPLOYMENT: 0
+      GITHUB_USER: ""
+      GITHUB_EMAIL: ""
     name: Update ${{ matrix.cfg.target }}
     steps:
     - name: Checkout ${{ matrix.cfg.target }}
@@ -26,11 +28,22 @@ jobs:
         repository: ${{ matrix.cfg.target }}
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
         persist-credentials: true
+    - name: GitHub user config
+      run: |
+        org=$(echo "${{ matrix.cfg.target }}" | cut -f1 -d"/")
+        user=$(jq -r --arg v "$org" '.[$v].user' $TEMPLATE_REPO_DIR/.github/workflows/github-users.json)
+        if [[ "$user" == "null" ]]; then
+          echo "No configuration found for GitHub org $org."
+          exit 1
+        fi
+        echo "Using GitHub user $user for $org."
+        echo "GITHUB_USER=$user" >> $GITHUB_ENV
+        echo "GITHUB_EMAIL=$user@users.noreply.github.com" >> $GITHUB_ENV
     - name: git config
       run: |
         cd $TARGET_REPO_DIR
-        git config user.name web3-bot
-        git config user.email "web3-bot@users.noreply.github.com"
+        git config user.name ${{ env.GITHUB_USER }}
+        git config user.email ${{ env.GITHUB_EMAIL }}
     - name: is initial test workflow deployment
       run: |
         if [[ ! -f $TARGET_REPO_DIR/.github/workflows/go-test.yml ]]; then
@@ -118,9 +131,9 @@ jobs:
           Syncing to commit ${{ github.event.client_payload.github_event.head_commit.url }}.
           
           ---
-          You can trigger a rebase by commenting `@web3-bot rebase`.
+          You can trigger a rebase by commenting `@${{ env.GITHUB_USER }} rebase`.
         token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-        committer: web3-bot <web3-bot@users.noreply.github.com>
-        author: web3-bot <web3-bot@users.noreply.github.com>
-        branch: web3-bot/sync
+        committer: ${{ env.GITHUB_USER }} <${{ env.GITHUB_EMAIL }}>
+        author: ${{ env.GITHUB_USER }} <${{ env.GITHUB_EMAIL }}>
+        branch: ${{ env.GITHUB_USER }}/sync
         delete-branch: true

--- a/.github/workflows/github-users.json
+++ b/.github/workflows/github-users.json
@@ -1,0 +1,23 @@
+{
+  "filecoin-project": {
+    "user": "web3-bot-filecoin"
+  },
+  "filecoin-shipyard": {
+    "user": "web3-bot"
+  },
+  "ipfs": {
+    "user": "web3-bot-ipfs"
+  },
+  "ipfs-cluster": {
+    "user": "web3-bot"
+  },
+  "ipld": {
+    "user": "web3-bot"
+  },
+  "libp2p": {
+    "user": "web3-bot"
+  },
+  "multiformats": {
+    "user": "web3-bot"
+  }
+}


### PR DESCRIPTION
IPFS and Filecoin already use separate GitHub users, which Andy created earlier today.
If everything works out, we'll also create separate GitHub users for all the other orgs. With this PR in place, all we have to do is update the user configuration in `github-users.json`.