### PR TITLE
use Go 1.16 to run go mod tidy, gofmt in copy workflow

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -32,6 +32,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
+    - uses: actions/setup-go@v2
+        with:
+          # This should be the same Go version we use in the go-check workflow.
+          # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
+          go-version: "1.16.x"
     - name: git config
       run: |
         cd $TARGET_REPO_DIR


### PR DESCRIPTION
For a demonstration of the problem, see https://github.com/libp2p/go-addr-util/pull/32/commits/9651346e5f362790f8d0cba1b1fc3ac8a268f0ab.

The copy workflow runs `go mod tidy` and `gofmt`, but with Go 1.15.x (don't ask me why that's the default version installed on GitHub Actions, I have no idea). The `go-check` workflow then runs these tools with Go 1.16.x, which might produce different results.