### PR TITLE
don't require go.sum in go-check workflow

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -13,11 +13,12 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
       - name: Check that go.mod is tidy
         run: |
-          cp go.mod go.mod.orig
-          cp go.sum go.sum.orig
           go mod tidy
-          diff go.mod go.mod.orig
-          diff go.sum go.sum.orig
+          if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
+            echo "go.sum was added by go mod tidy"
+            exit 1
+          fi
+          git diff --exit-code -- go.sum go.mod
       - name: gofmt
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         run: |


### PR DESCRIPTION
Fixes #73.

If `go.mod` doesn't contain any dependencies, it's not necessary to have a `go.sum` file.

Unfortunately, this change will trigger a PR in all repos that we've deployed to so far.