### PR TITLE
fix indent in copy workflow

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -33,10 +33,10 @@ jobs:
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
     - uses: actions/setup-go@v2
-        with:
-          # This should be the same Go version we use in the go-check workflow.
-          # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
-          go-version: "1.16.x"
+      with:
+        # This should be the same Go version we use in the go-check workflow.
+        # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
+        go-version: "1.16.x"
     - name: git config
       run: |
         cd $TARGET_REPO_DIR


### PR DESCRIPTION
Delaying merge until #74 is merged, in order to minimize the number of PRs we create.