### PR TITLE
chore: add go-merkledag

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   { "target": "filecoin-project/go-amt-ipld" },
   { "target": "filecoin-project/go-fil-commp-hashhash" },
   { "target": "filecoin-project/go-hamt-ipld" },
+  { "target": "ipfs/go-merkledag" },
   { "target": "ipld/go-car" },
   { "target": "ipld/go-codec-dagpb" },
   { "target": "ipld/go-ipld-adl-hamt" },


### PR DESCRIPTION
CI is currently broken anyways.