### PR TITLE
support multi-module repos

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -13,12 +13,15 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
       - name: Check that go.mod is tidy
         run: |
-          go mod tidy
-          if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
+          while read -r mod; do
+            ( cd "$(dirname "$mod")" && go mod tidy )
+          done < <(find -name go.mod)
+
+          if [[ -n $(git ls-files --other --exclude-standard --directory -- 'go.sum' '**/go.sum') ]]; then
             echo "go.sum was added by go mod tidy"
             exit 1
           fi
-          git diff --exit-code -- go.sum go.mod
+          git diff --exit-code -- 'go.sum' '**/go.sum' 'go.mod' '**/go.mod'
       - name: gofmt
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         run: |
@@ -29,10 +32,14 @@ jobs:
           fi
       - name: go vet
         if: ${{ success() || failure() }} # run this step even if the previous one failed
-        run: go vet ./...
+        run: |
+          while read -r mod; do
+            ( cd "$(dirname "$mod")" && go vet ./... )
+          done < <(find -name go.mod)
       - name: staticcheck
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         run: |
-          set -o pipefail
-          staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
-
+          while read -r mod; do
+            moddir="$(dirname "$mod")"
+            ( cd "$moddir" && staticcheck ./... | sed -e "s@\(.*\)\.go@${moddir}/\1.go@g" )
+          done < <(find -name go.mod)

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -7,6 +7,9 @@ jobs:
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
         go: [ "1.15.x", "1.16.x" ]
+    defaults:
+      run:
+        shell: bash # Git bash on windows.
     runs-on: ${{ matrix.os }}-latest
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     steps:
@@ -19,15 +22,24 @@ jobs:
           go version
           go env
       - name: Run tests
-        run: go test -v -coverprofile coverage.txt ./...
+        run: |
+          while read -r mod; do
+            ( cd "$(dirname "$mod")" && go test -v -coverprofile coverage.txt ./... )
+          done < <(find -name go.mod)
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
         env:
           GOARCH: 386
-        run: go test -v ./...
+        run: |
+          while read -r mod; do
+            ( cd "$(dirname "$mod")" && go test -v ./... )
+          done < <(find -name go.mod)
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
-        run: go test -v -race ./...
+        run: |
+          while read -r mod; do
+            ( cd "$(dirname "$mod")" && go test -v -race ./... )
+          done < <(find -name go.mod)
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2 # v1.4.1
         with:


### PR DESCRIPTION
Run tests, build, vet, check, etc. for every module.

This also sets the default shell to "bash" (so this should work on windows).