### PR TITLE
update the Codecov Action to v1.5.0

### DIFF
--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         run: go test -v -race ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2 # v1.4.1
+        uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27 # v1.5.0
         with:
           file: coverage.txt
           env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}


### PR DESCRIPTION
[Codecov 1.5.0](https://github.com/codecov/codecov-action/releases/tag/v1.5.0) moved the uploader script to the Action itself. That seems to be a safer approach than downloading it from the Codecov server.