### PR TITLE
add a cron workflow to find deleted repositories

### DIFF
--- a/.github/workflows/stale-repos.yml
+++ b/.github/workflows/stale-repos.yml
@@ -1,0 +1,23 @@
+on:
+  schedule:
+  - cron: "0 */6 * * *" # every 6 hours
+
+jobs:
+  matrix:
+    name: Find stale repositories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: find deleted repositories
+        run: |
+          status=0
+          for repo in $(jq -r '.[].target' config.json); do
+            tmp=$(mktemp -d)
+            if ! git clone -q --depth 1 "https://github.com/$repo" "$tmp" 2> /dev/null; then
+              echo "Repository $repo does not exist."
+              status=1
+            fi
+            rm -rf $tmp || true
+          done
+          exit $status
+      

--- a/.github/workflows/stale-repos.yml
+++ b/.github/workflows/stale-repos.yml
@@ -8,16 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: find deleted repositories
+      - name: find deleted / archived repositories
         run: |
           status=0
           for repo in $(jq -r '.[].target' config.json); do
-            tmp=$(mktemp -d)
-            if ! git clone -q --depth 1 "https://github.com/$repo" "$tmp" 2> /dev/null; then
+            exists=true
+            output=$(curl -s -f -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$repo") || exists=false
+            if ! $exists; then
               echo "Repository $repo does not exist."
               status=1
+              continue
             fi
-            rm -rf $tmp || true
+            if [[ $(echo "$output" | jq ".archived") == "true" ]]; then
+              echo "Repository $repo is archived."
+              status=1
+            fi
           done
           exit $status
       


### PR DESCRIPTION
Turns out we already have one deleted repo in our list (ipfs/go-ipfs-blockutil), and one archived one (ipfs/go-ipfs-cmdkit).
Sample run: https://github.com/protocol/.github/runs/2604478580?check_suite_focus=true

Future steps:
- Run this workflow on `pull_request` as well, but only only on newly added repos (if any).
- Create a PR that fixes `config.json` (this is probably overkill, we don't archive repos that often).