### PR TITLE
checkout submodules (recursively)

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -6,6 +6,8 @@ jobs:
     name: Go checks
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v2
         with:
           go-version: "1.16.x"

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -11,6 +11,8 @@ jobs:
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
Some of our repos use git submodules. We need to tell the checkout action to clone submodules.

Example: https://github.com/multiformats/go-multibase/pull/43.