### PR TITLE
add support for repositories with multiple Go modules

### DIFF
--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -5,7 +5,7 @@ status=0
 
 for line in `sed -ne 's/[[:space:]-]*uses:[[:space:]]*//p' $1 | sed -e 's/\s*#.*$//'`; do
   author=`echo $line | awk -F/ '{print $1}'`
-  if [[ $author == "actions" ]]; then continue; fi
+  if [[ $author == "actions" || $author == "protocol" ]]; then continue; fi
   version=`echo $line | awk -F@ '{print $2}' | awk '{print $1}'`
   if ! [[ "$version" =~ ^[a-f0-9]{40}$ ]]; then
     status=1

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
       - name: Check that go.mod is tidy
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         with:
           run: |
             go mod tidy
@@ -31,12 +31,12 @@ jobs:
           fi
       - name: go vet
         if: ${{ success() || failure() }} # run this step even if the previous one failed
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         with:
           run: go vet ./...
       - name: staticcheck
         if: ${{ success() || failure() }} # run this step even if the previous one failed
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         with:
           run: |
             set -o pipefail

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -12,13 +12,15 @@ jobs:
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
       - name: Check that go.mod is tidy
-        run: |
-          go mod tidy
-          if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
-            echo "go.sum was added by go mod tidy"
-            exit 1
-          fi
-          git diff --exit-code -- go.sum go.mod
+        uses: protocol/multiple-go-modules@master
+        with:
+          run: |
+            go mod tidy
+            if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
+              echo "go.sum was added by go mod tidy"
+              exit 1
+            fi
+            git diff --exit-code -- go.sum go.mod
       - name: gofmt
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         run: |
@@ -29,10 +31,14 @@ jobs:
           fi
       - name: go vet
         if: ${{ success() || failure() }} # run this step even if the previous one failed
-        run: go vet ./...
+        uses: protocol/multiple-go-modules@master
+        with:
+          run: go vet ./...
       - name: staticcheck
         if: ${{ success() || failure() }} # run this step even if the previous one failed
-        run: |
-          set -o pipefail
-          staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+        uses: protocol/multiple-go-modules@master
+        with:
+          run: |
+            set -o pipefail
+            staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
 

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -19,19 +19,19 @@ jobs:
           go version
           go env
       - name: Run tests
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         with:
           run: go test -v -coverprofile coverage.txt ./...
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         env:
           GOARCH: 386
         with:
           run: go test -v ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
-        uses: protocol/multiple-go-modules@master
+        uses: protocol/multiple-go-modules@v1.0
         with:
           run: go test -v -race ./...
       - name: Upload coverage to Codecov

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -19,15 +19,21 @@ jobs:
           go version
           go env
       - name: Run tests
-        run: go test -v -coverprofile coverage.txt ./...
+        uses: protocol/multiple-go-modules@master
+        with:
+          run: go test -v -coverprofile coverage.txt ./...
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
+        uses: protocol/multiple-go-modules@master
         env:
           GOARCH: 386
-        run: go test -v ./...
+        with:
+          run: go test -v ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
-        run: go test -v -race ./...
+        uses: protocol/multiple-go-modules@master
+        with:
+          run: go test -v -race ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2 # v1.4.1
         with:


### PR DESCRIPTION
Closes #89.

Note: Codecov coverage reports are only uploaded for the main repo. Fixing this will be more difficult.