### PR TITLE
use the retry branch of peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -124,7 +124,7 @@ jobs:
         echo "NEEDS_UPDATE=$(git rev-list HEAD...origin/$(git rev-parse --abbrev-ref HEAD) --ignore-submodules --count)" >> $GITHUB_ENV
     - name: Create Pull Request
       if: ${{ env.NEEDS_UPDATE }}
-      uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 #v3.8.2
+      uses: peter-evans/create-pull-request@89a67b1c69299ccc4dcc2253c3e91001adba29b5 # https://github.com/peter-evans/create-pull-request/pull/856
       with:
         path: ${{ env.TARGET_REPO_DIR }}
         title: "sync: update CI config files"


### PR DESCRIPTION
A while back, we ran into GitHub's abuse detection mechanism when we tried to deploy updates to dozens of repos.
I expect that to happen again when we deploy to 100 repos now.

Yesterday, I opened https://github.com/peter-evans/create-pull-request/issues/855 and already got a reply there, including a branch to test. We can help test this change.
The plan is to first trigger a deployment, using the original version of _create-pull-request_, then merge this PR, and see if it helps.