### PR TITLE
chore: add libp2p/go-libp2p-quic-transport

### DIFF
--- a/config.json
+++ b/config.json
@@ -107,6 +107,7 @@
   { "target": "libp2p/go-libp2p-peerstore" },
   { "target": "libp2p/go-libp2p-pnet" },
   { "target": "libp2p/go-libp2p-pubsub-router" },
+  { "target": "libp2p/go-libp2p-quic-transport" },
   { "target": "libp2p/go-libp2p-raft" },
   { "target": "libp2p/go-libp2p-routing-helpers" },
   { "target": "libp2p/go-libp2p-swarm" },


### PR DESCRIPTION
Depends on https://github.com/libp2p/go-libp2p-quic-transport/pull/211.