### PR TITLE
chore: add ipld/go-storethehash

### DIFF
--- a/config.json
+++ b/config.json
@@ -68,6 +68,7 @@
   { "target": "ipld/go-ipld-btc" },
   { "target": "ipld/go-ipld-graphql" },
   { "target": "ipld/go-ipld-prime-proto" },
+  { "target": "ipld/go-storethehash" },
   { "target": "libp2p/go-addr-util" },
   { "target": "libp2p/go-buffer-pool" },
   { "target": "libp2p/go-conn-security-multistream" },


### PR DESCRIPTION
Adds CI to `go-storethehash`: https://github.com/ipld/go-storethehash/issues/3