### PR TITLE
Remove `.gx` on initial deployment

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -72,13 +72,13 @@ jobs:
           git rm -r .circleci
           git commit -m "disable CircleCI"
         fi
-    - name: remove GX on initial deployment
+    - name: remove gx on initial deployment
       if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
       run: |
         cd $TARGET_REPO_DIR
         if [[ -d .gx ]]; then
           git rm -r .gx
-          git commit -m "disable GX"
+          git commit -m "remove .gx"
         fi
     - name: run go mod tidy
       run: |

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -72,6 +72,14 @@ jobs:
           git rm -r .circleci
           git commit -m "disable CircleCI"
         fi
+    - name: remove GX on initial deployment
+      if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 }}
+      run: |
+        cd $TARGET_REPO_DIR
+        if [[ -d .gx ]]; then
+          git rm -r .gx
+          git commit -m "disable GX"
+        fi
     - name: run go mod tidy
       run: |
         cd $TARGET_REPO_DIR


### PR DESCRIPTION
Update the copy workflow to remove `.gx` if it is present now that GX
has become redundant in favour of `go.mod`.

Relates to:
- https://github.com/whyrusleeping/gx