### PR TITLE
fail CI build when bash scripts error

### DIFF
--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 FILE=$1
 status=0
 

--- a/.github/workflows/check-config.sh
+++ b/.github/workflows/check-config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 file=$1
 entries=$(mktemp)
 entries_sorted=$(mktemp)


### PR DESCRIPTION
This is why CI didn't catch this malformed JSON document: https://github.com/protocol/.github/pull/146#discussion_r676722534.