### PR TITLE
chore: remove ipfs/go-hamt-ipld

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,6 @@
   { "target": "ipfs/go-fetcher" },
   { "target": "ipfs/go-filestore" },
   { "target": "ipfs/go-fs-lock" },
-  { "target": "ipfs/go-hamt-ipld" },
   { "target": "ipfs/go-ipfs-blockstore" },
   { "target": "ipfs/go-ipfs-blocksutil" },
   { "target": "ipfs/go-ipfs-chunker" },


### PR DESCRIPTION
This repo is just a shim for backwards compat and has now been archived.