### PR TITLE
remove ipfs-shipyard/go-ipfs-desktop

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,6 @@
   { "target": "filecoin-project/go-hamt-ipld" },
   { "target": "filecoin-project/go-indexer-core" },
   { "target": "filecoin-project/storetheindex" },
-  { "target": "ipfs-shipyard/go-ipfs-desktop" },
   { "target": "ipfs-shipyard/ipfs-counter" },
   { "target": "ipfs/bbloom" },
   { "target": "ipfs/go-bitfield" },


### PR DESCRIPTION
I've added it to a new "on hold" tab in the tracker doc,
with the following reason:

	Requires extra libraries for cgo.

The CI jobs simply fail now, as we don't support any customization of
the workflows, and Linux packages are missing.

We will likely support that kind of customization in the future, but not
right now.