### PR TITLE
chore: add ipld/codec-fixtures

### DIFF
--- a/config.json
+++ b/config.json
@@ -77,6 +77,7 @@
   { "target": "ipfs/iptb-plugins" },
   { "target": "ipfs/pinbot-irc" },
   { "target": "ipfs/tar-utils" },
+  { "target": "ipld/codec-fixtures" },
   { "target": "ipld/go-car" },
   { "target": "ipld/go-codec-dagpb" },
   { "target": "ipld/go-ipld-adl-hamt" },


### PR DESCRIPTION
We probably want to delay merging this PR until we merge the `next` branch (because there we also run `go mod tidy` in sub-packages).