### PR TITLE
fix invalid quotes in copy workflow

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -145,7 +145,7 @@ jobs:
         fi
     - name: Add files
       run: |
-        for f in $(jq -r ".[]" <<< '${{ toJson(github.event.inputs.files) }}'); do
+        for f in $(jq -r ".[]" <<< ${{ toJson(github.event.inputs.files) }}); do
           echo -e "\nProcessing $f."
           # add DO NOT EDIT header
           tmp=$(mktemp)


### PR DESCRIPTION
Otherwise the copy workflow fails:
```
> Run for f in $(jq -r ".[]" <<< '"[ \".github/workflows/automerge.yml\", \".github/workflows/go-test.yml\", \".github/workflows/go-check.yml\" ]"'); do
jq: error (at <stdin>:1): Cannot iterate over string ("[ \".githu...)
```