### PR TITLE
replace the $default-branch placeholder in workflows

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -31,6 +31,7 @@ jobs:
       GO_VERSION_BUMP: 0
       GITHUB_USER: "web3-bot"
       GITHUB_EMAIL: "web3-bot@users.noreply.github.com"
+      DEFAULTBRANCH: ""
     name: ${{ matrix.cfg.target }}
     steps:
     - name: Checkout ${{ matrix.cfg.target }}
@@ -50,6 +51,12 @@ jobs:
         # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
         stable: 'false'
         go-version: "1.17.0-rc1"
+    - name: determine GitHub default branch
+      working-directory: ${{ env.TARGET_REPO_DIR }}
+      run: |
+        defaultbranch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+        echo $defaultbranch
+        echo "DEFAULTBRANCH=$defaultbranch" >> $GITHUB_ENV
     - name: git config
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: |
@@ -150,6 +157,8 @@ jobs:
           # add DO NOT EDIT header
           tmp=$(mktemp)
           cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f > $tmp
+          # replace $default-branch with this repo's GitHub default branch
+          sed -i "s/\$default-branch/${{ env.DEFAULTBRANCH }}/g" $tmp
           mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f
           # create commit, if necessary
           commit_msg=""


### PR DESCRIPTION
Problem:
1. GitHub renamed the `master` branch to `main`. Some of our repos use `master` and some use `main` as default branch. We can't rely on this branch being the default branch any more.
2. There's no way to specify to run a workflow on just the default branch, e.g.:
```yml
on:
  push:
     branches:
        - $default-branch
```

This PR makes it possible to use a definition as given in the yaml above. The copy workflow then determines the default branch of the repo and replaces all occurrences of `$default-branch` with that branch name.