### PR TITLE
run go generate if enabled in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ By storing them in a central place (here), and distributing them in an automated
 
 ## Customization
 
+### Additional Setup Steps
+
 Most repositories won't need any customization, and the workflows defined here will just work fine.
 Some repositories may require some pre-setup steps to be run before tests (or code checks) can be run. Setup steps for `go-test` are defined in `.github/actions/go-test-setup/action.yml`, and setup steps for `go-check` are defined in `.github/actions/go-check-setup/action.yml`, in the following format:
 
@@ -24,6 +26,21 @@ runs:
 ```
 
 These setup steps are run after the repository has been checked out and after Go has been installed, but before any tests or checks are run.
+
+### Configuration
+
+`go-check` contains an optional step that checks that running `go generate` doesn't change any files.
+This is useful to make sure that the generated code stays in sync.
+
+This check will be run in repositories that set `gogenerate` to `true` in `.github/workflows/go-check-config.json`:
+```json
+{
+  "gogenerate": true
+}
+```
+
+Note that depending on the code generators used, it might be necessary to [install those first](#additional-setup-steps).
+The generators must also be deterministic, to prevent CI from getting different results each time.
 
 ## Technical Details
 

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -5,6 +5,8 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     name: All
+    env:
+      RUNGOGENERATE: false
     steps:
       - uses: actions/checkout@v2
         with:
@@ -15,6 +17,12 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''
+      - name: Read config
+        if: hashFiles('./.github/workflows/go-check-config.json') != ''
+        run: |
+          if jq -re .gogenerate ./.github/workflows/go-check-config.json; then
+            echo "RUNGOGENERATE=true" >> $GITHUB_ENV
+          fi
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@434f5f3816b358fe468fa83dcba62d794e7fe04b # 2021.1 (v0.2.0)
       - name: Check that go.mod is tidy
@@ -47,4 +55,17 @@ jobs:
           run: |
             set -o pipefail
             staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+      - name: go generate
+        uses: protocol/multiple-go-modules@v1.2
+        if: (success() || failure()) && env.RUNGOGENERATE == 'true'
+        with:
+          run: |
+            git clean -fd # make sure there aren't untracked files / directories
+            go generate ./...
+            gitstatus=$(git status --porcelain)
+            if [[ -n "$gitstatus" ]]; then
+              echo "go generated caused changes to the repository:"
+              echo "$gitstatus"
+              exit 1
+            fi
 

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -62,10 +62,10 @@ jobs:
           run: |
             git clean -fd # make sure there aren't untracked files / directories
             go generate ./...
-            gitstatus=$(git status --porcelain)
-            if [[ -n "$gitstatus" ]]; then
+            # check if go generate modified or added any files
+            if ! $(git add . && git diff-index HEAD --exit-code --quiet); then
               echo "go generated caused changes to the repository:"
-              echo "$gitstatus"
+              git status --short
               exit 1
             fi
 


### PR DESCRIPTION
Fixes #123.

This PR introduces a new concept: Repositories can create a config file `.github/workflows/go-check-config.json` to enable an additional step in the `go-check` workflow: running `go generate ./...` to make sure that no files are modified or added.
This is a backwards-compatible change: If the config file doesn't exist, we don't run that step.