### PR TITLE
Add reminder in README to add permissions to web3-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Workflows are distributed to all repositories listed in [config.json](config.jso
 
 If you want your project to participle, please send a PR!
 
+In order for the CI to be fully integrated, remember to grant write access permissions to the `web3-bot` user.
+
 ## Development
 
 The `master` branch contains currently deployed workflows.


### PR DESCRIPTION
I keep asking myself when setting up CI in a new repo *"why is the CI not being integrated?"* and it always ends up being that `web3-bot` doesn't have access to the repo. I suggest adding a quick note in the README for folks like me :)