### PR TITLE
run go mod tidy right after bumping the Go version number

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -111,6 +111,7 @@ jobs:
 
             # Update the version in go.mod. This alone ensures there's a diff.
             go mod edit -go $TARGET_VERSION
+            go mod tidy
 
             # In the future, "go fix" may make changes to Go code,
             # such as to adapt to language changes or API deprecations.
@@ -120,10 +121,10 @@ jobs:
 
             # We don't tidy, because the next step does that.
             # Separate commits also help with reviews.
-            git commit -m "bump go.mod to Go $TARGET_VERSION and run go fix"
+            git commit -m "bump go.mod to Go $TARGET_VERSION, run go fix and go mod tidy"
           fi
-    - name: go mod tidy (on initial deployment and on new Go version)
-      if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 || env.GO_VERSION_BUMP == 1}}
+    - name: go mod tidy (on initial deployment)
+      if: ${{ env.INITIAL_TEST_DEPLOYMENT == 1 && env.GO_VERSION_BUMP != 1 }}
       uses: protocol/multiple-go-modules@v1.2
       with:
         working-directory: ${{ env.TARGET_REPO_DIR }}

--- a/config-testing.json
+++ b/config-testing.json
@@ -1,3 +1,3 @@
 [
-  { "target": "protocol/.github-test-target" }
+  { "target": "libp2p/go-libp2p-autonat" }
 ]


### PR DESCRIPTION
Otherwise the workflow might fail, as happened here: https://github.com/protocol/.github/runs/3381383509?check_suite_focus=true:

![image](https://user-images.githubusercontent.com/1478487/130227405-ac622aa4-8273-4d05-b83d-8d634b7ab348.png)
