### PR TITLE
Add js-lotus-client-schema

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
   { "target": "filecoin-project/go-indexer-core" },
   { "target": "filecoin-project/indexer-reference-provider" },
   { "target": "filecoin-project/storetheindex" },
+  { "target": "filecoin-shipyard/js-lotus-client-schema" },
   { "target": "ipfs-shipyard/ipfs-counter" },
   { "target": "ipfs/bbloom" },
   { "target": "ipfs/go-bitfield" },


### PR DESCRIPTION
Similar to #166, I'm not sure if we're ready to handle these cases or not? There's two folders containing Go packages, no root go.mod.
