### PR TITLE
chore: add ipfs-shipyard/dnslink-dnsimple

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
   { "target": "filecoin-project/indexer-reference-provider" },
   { "target": "filecoin-project/storetheindex" },
   { "target": "filecoin-shipyard/js-lotus-client-schema" },
+  { "target": "ipfs-shipyard/dnslink-dnsimple" },
   { "target": "ipfs-shipyard/git-remote-ipld" },
   { "target": "ipfs-shipyard/ipfs-counter" },
   { "target": "ipfs/bbloom" },


### PR DESCRIPTION
Depends on https://github.com/ipfs-shipyard/dnslink-dnsimple/pull/11.