### PR TITLE
chore: add libp2p/go-openssl

### DIFF
--- a/config.json
+++ b/config.json
@@ -141,6 +141,7 @@
   { "target": "libp2p/go-msgio" },
   { "target": "libp2p/go-nat" },
   { "target": "libp2p/go-netroute" },
+  { "target": "libp2p/go-openssl" },
   { "target": "libp2p/go-reuseport" },
   { "target": "libp2p/go-reuseport-transport" },
   { "target": "libp2p/go-routing-language" },


### PR DESCRIPTION
Depends on https://github.com/libp2p/go-openssl/pull/16.