### PR TITLE
fix the path trigger in the check-config workflow

### DIFF
--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -1,7 +1,7 @@
 on: 
   pull_request:
     paths:
-      - './config.json'
+      - 'config.json'
 
 name: Check Config
 


### PR DESCRIPTION
Apparently GitHub Actions doesn't like the `./`.