### PR TITLE
improve readability of release-check workflow by renaming env vars

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -7,10 +7,10 @@ jobs:
     env:
       INITIAL_RUN: "false"
       VERSION: "" # the version number read from version.json
-      COMPARETO: "" # the version number to compare this version to
-      GORELEASE: ""
-      GOCOMPAT: ""
-      GOMODDIFF: ""
+      COMPARE_TO: "" # the version number to compare this version to
+      GORELEASE_OUTPUT: ""
+      GOCOMPAT_OUTPUT: ""
+      GOMOD_DIFF: ""
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -55,9 +55,9 @@ jobs:
             echo $v
             exit $status
           fi
-          echo "COMPARETO=$v" >> $GITHUB_ENV
+          echo "COMPARE_TO=$v" >> $GITHUB_ENV
       - name: Post output
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO == ''
+        if: env.INITIAL_RUN == 'false' && env.COMPARE_TO == ''
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
         with:
           header: release-check
@@ -67,55 +67,55 @@ jobs:
 
             This is the first release of this module.
       - name: run git diff on go.mod file(s)
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.INITIAL_RUN == 'false' && env.COMPARE_TO != ''
         run: |
           # First get the diff for the go.mod file in the root directory...
-          output=$(git diff ${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }} -- './go.mod')
+          output=$(git diff ${{ env.COMPARE_TO }}..${{ github.event.pull_request.head.sha }} -- './go.mod')
           # ... then get the diff for all go.mod files in subdirectories.
           # Note that this command also finds go.mod files more than one level deep in the directory structure. 
-          output+=$(git diff ${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }} -- '*/go.mod')
+          output+=$(git diff ${{ env.COMPARE_TO }}..${{ github.event.pull_request.head.sha }} -- '*/go.mod')
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "GOMODDIFF<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
+          printf "GOMOD_DIFF<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
       - name: Run gorelease
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.INITIAL_RUN == 'false' && env.COMPARE_TO != ''
         # see https://github.com/golang/exp/commits/master/cmd/gorelease
         run: |
           go install golang.org/x/exp/cmd/gorelease@b4e88ed8e8aab63a9aa9a52276782ebbc547adef
-          output=$((gorelease -base ${{ env.COMPARETO }}) 2>&1 || true)
-          printf "GORELEASE<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
+          output=$((gorelease -base ${{ env.COMPARE_TO }}) 2>&1 || true)
+          printf "GORELEASE_OUTPUT<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
       - name: Check Compatibility
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.INITIAL_RUN == 'false' && env.COMPARE_TO != ''
         run: |
           go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
-          output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }}" ./... || true)
+          output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARE_TO }}..${{ github.event.pull_request.head.sha }}" ./... || true)
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "GOCOMPAT<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
+          printf "GOCOMPAT_OUTPUT<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
       - name: Post output
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.INITIAL_RUN == 'false' && env.COMPARE_TO != ''
         with:
           header: release-check
           recreate: true
           message: |
             Suggested version: `${{ env.VERSION }}`
-            Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.ref }}))
+            Comparing to: [`${{ env.COMPARE_TO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARE_TO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARE_TO }}..${{ github.event.pull_request.head.ref }}))
 
             Changes in `go.mod` file(s):
             ```diff
-            ${{ env.GOMODDIFF }}
+            ${{ env.GOMOD_DIFF }}
             ```
 
             `gorelease` says:
             ```
-            ${{ env.GORELEASE }}
+            ${{ env.GORELEASE_OUTPUT }}
             ```
 
             `gocompat` says:
             ```
-            ${{ env.GOCOMPAT }}
+            ${{ env.GOCOMPAT_OUTPUT }}
             ```
 


### PR DESCRIPTION
No functional change expected. This is literally just a "search-and-replace" change.