### PR TITLE
alternative: use msys2 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@ runs:
       run: echo "do some initial setup"
     - name: Step 2
       shell: bash
-      run: |
-        # note that it's not possible to use if: on the step, see https://github.com/actions/runner/issues/834
-        if [[ "${{ matrix.os }}" == "ubuntu" ]]; then
-          echo "do some Linux-specific setup"
-        fi
+      run: echo "do some Linux-specific setup"
+      if: ${{ matrix.os == 'ubuntu' }}
 ```
 
 These setup steps are run after the repository has been checked out and after Go has been installed, but before any tests or checks are run.

--- a/config.json
+++ b/config.json
@@ -35,6 +35,7 @@
   { "target": "ipfs/go-ds-pebble" },
   { "target": "ipfs/go-ds-redis" },
   { "target": "ipfs/go-ds-s3" },
+  { "target": "ipfs/go-ds-sql" },
   { "target": "ipfs/go-fetcher", "deploy_versioning": true },
   { "target": "ipfs/go-filestore", "deploy_versioning": true },
   { "target": "ipfs/go-fs-lock" },

--- a/config.json
+++ b/config.json
@@ -87,7 +87,7 @@
   { "target": "ipfs/iptb" },
   { "target": "ipfs/iptb-plugins" },
   { "target": "ipfs/pinbot-irc" },
-  { "target": "ipfs/tar-utils" },
+  { "target": "ipfs/tar-utils", "deploy_versioning": true },
   { "target": "ipld/codec-fixtures" },
   { "target": "ipld/go-car", "deploy_versioning": true },
   { "target": "ipld/go-codec-dagpb" },

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   { "target": "filecoin-project/go-fil-commp-hashhash" },
   { "target": "filecoin-project/go-hamt-ipld" },
   { "target": "filecoin-project/go-indexer-core" },
+  { "target": "filecoin-project/go-legs" },
   { "target": "filecoin-project/indexer-reference-provider" },
   { "target": "filecoin-project/storetheindex" },
   { "target": "filecoin-shipyard/js-lotus-client-schema" },

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           go version
           go env
+      - name: Use msys2 on windows
+        if: ${{ matrix.os == 'windows' }}
+        shell: bash
+        run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Use msys2 on windows
         if: ${{ matrix.os == 'windows' }}
         shell: bash
+        # The executable for msys2 is also called bash.cmd
+        #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#shells
+        # If we prepend its location to the PATH
+        #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
         run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup


### PR DESCRIPTION
This is an alternative way of using msys2bash on windows machines during go-test runs.

It prepends `C:/msys64/usr/bin` to `PATH`. After this, whenever we request `shell: bash`, `msys2`'s version will be picked ahead of `git`'s. 

With the original PR (https://github.com/protocol/.github/pull/221) the workflow wasn't able to find the paths specified in https://github.com/protocol/multiple-go-modules/blob/master/action.yml#L28:
```
New-Item : Cannot find path 'D:\a\_temp\setup-msys2\msys2.cmd' because it does not exist.
At line:1 char:1
+ New-Item -ItemType SymbolicLink -Path D:/a/_temp/setup-msys2/bash-or- ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\a\_temp\setup-msys2\msys2.cmd:String) [New-Item], ItemNotFoundExcept 
   ion
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.NewItemCommand
 
Error: Process completed with exit code 1.
```

This alternative setup has been tested in https://github.com/libp2p/go-openssl/pull/19 (NOTE: the red checkmarks are due to 32 bit tests failing which is unrelated to this change). If you inspect the windows tests run please have a look at shell description - `shell: C:/msys64/usr/bin\bash.EXE`.

I've found this way of accomplishing the task by inspecting installed software on windows runners: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#msys2

