### PR TITLE
Replace concurrency setup with max-parallel=1 strategy in copy-workflow

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(github.event.inputs.targets) }}
+      max-parallel: 1
     env:
       TARGET_REPO_DIR: "target-repo"
       TEMPLATE_REPO_DIR: "template-repo"

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -14,9 +14,6 @@ on:
       targets:
         description: "List of repositories to deploy to"
         required: true
-      concurrency_group:
-        description: "Concurrency Group"
-        required: true
 
 jobs:
   copy:
@@ -25,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(github.event.inputs.targets) }}
-    concurrency: copy-${{ github.event.inputs.concurrency_group }}
     env:
       TARGET_REPO_DIR: "target-repo"
       TEMPLATE_REPO_DIR: "template-repo"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -52,4 +52,4 @@ jobs:
         with:
           workflow: "Deploy" # "name" attribute of copy-workflow.yml
           token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-          inputs: '{ "head_commit_url": ${{ toJson(github.event.head_commit.url) }}, "files": ${{ toJson(env.FILES) }}, "targets": ${{ toJson(toJson(matrix.cfg.value)) }}, "concurrency_group": "${{ matrix.cfg.key }}" }'
+          inputs: '{ "head_commit_url": ${{ toJson(github.event.head_commit.url) }}, "files": ${{ toJson(env.FILES) }}, "targets": ${{ toJson(toJson(matrix.cfg.value)) }} }'

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -8,8 +8,7 @@ on:
 
 env:
   # Number of repositories in a batch.
-  # Deployment jobs in the same batch use the same concurrency group,
-  # and are therefore run sequentially.
+  # Deployment jobs in the same batch are run sequentially.
   # With ~180 repos, this means we'll run around 9 instances of the copy workflow in parallel.
   # This is (hopefully) sufficient to prevent us from triggering GitHub Action's abuse detection mechanism.
   MAX_REPOS_PER_WORKFLOW: 20


### PR DESCRIPTION
With current `concurrency` setup only the first and the last matrix job was run and the rest were cancelled with `Canceling since a higher priority waiting request for 'copy-*' exists`.

The [concurrency documentations](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) explains this as follows:
```
Any previously pending job or workflow in the concurrency group will be canceled.
```

I think settings `strategy.max-parallel: 1` in `copy-workflow` might do what we want it to which is to run all the matrix jobs within one copy-workflow instance sequentially: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel

One thing to watch out for is if the job sequence will continue after a failure but I think it will because of the `fail-fast: false` setting.