### PR TITLE
try to avoid hitting secondary rate limit

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -22,6 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(github.event.inputs.targets) }}
+      # This controls how many matrix jobs can run in parallel.
+      # We keep it low trying not to hit GitHub's secondary rate limit mechanism.
       max-parallel: 1
     env:
       TARGET_REPO_DIR: "target-repo"
@@ -207,3 +209,7 @@ jobs:
         author: ${{ env.GITHUB_USER }} <${{ env.GITHUB_EMAIL }}>
         branch: ${{ env.GITHUB_USER }}/sync
         delete-branch: true
+    - name: Sleep
+      if: ${{ env.NEEDS_UPDATE }}
+      run: sleep 10
+      shell: bash

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -7,11 +7,9 @@ on:
     branches: [ master, testing ]
 
 env:
-  # Number of repositories in a batch.
-  # Deployment jobs in the same batch are run sequentially.
-  # With ~180 repos, this means we'll run around 9 instances of the copy workflow in parallel.
-  # This is (hopefully) sufficient to prevent us from triggering GitHub Action's abuse detection mechanism.
-  MAX_REPOS_PER_WORKFLOW: 20
+  # The downstream workflow creates a matrix job per repository.
+  # 256 is the limit for number of matrix jobs a workflow can create.
+  MAX_REPOS_PER_WORKFLOW: 256
   FILES: '[ ".github/workflows/automerge.yml", ".github/workflows/go-test.yml", ".github/workflows/go-check.yml", ".github/workflows/releaser.yml", ".github/workflows/release-check.yml", ".github/workflows/tagpush.yml" ]' # a JSON array of the files to distribute
 
 jobs:
@@ -45,8 +43,11 @@ jobs:
         # The triggered copy-workflow jobs use that final array as their matrix.
         # As such, we'll end up with one copy-workflow parallel job per target.
         cfg: ${{ fromJson(needs.matrix.outputs.targets) }}
+      max-parallel: 1
     name: Start copy workflow (batch ${{ matrix.cfg.key }})
     steps:
+      # We want only one copy-workflow running at a time
+      # For this to be true workflow-dispatch would have to wait for the result
       - uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1.1.0
         with:
           workflow: "Deploy" # "name" attribute of copy-workflow.yml


### PR DESCRIPTION
I propose to run a single batch at a time and introduce a 10s sleep after PR create to try and avoid hitting GitHub secondary rate limit. These values are quite caution because I'd want us to get a successful run across all repos and only then move on to trying to optimise it.

With these setting, the entire job should take around 180*30s=90m.