### PR TITLE
Revert "include cross-package coverage in codecov"

### DIFF
--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -37,10 +37,7 @@ jobs:
       - name: Run tests
         uses: protocol/multiple-go-modules@v1.2
         with:
-          # Use -coverpkg=./..., so that we include cross-package coverage.
-          # If package ./A imports ./B, and ./A's tests also cover ./B,
-          # this means ./B's coverage will be significantly higher than 0%.
-          run: go test -v -coverprofile=module-coverage.txt -coverpkg=./... ./...
+          run: go test -v -coverprofile module-coverage.txt ./...
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
Reverts protocol/.github#210

https://github.com/golang/go/commit/c59b17e5a2244f7a99c440a07a1c174344da0ad8 is not included in go 1.16. We're going to revert the revert once we move to go 1.18.