### PR TITLE
remove http-api-docs from config.json because it was archived

### DIFF
--- a/config.json
+++ b/config.json
@@ -79,7 +79,6 @@
   { "target": "ipfs/go-unixfsnode" },
   { "target": "ipfs/go-verifcid" },
   { "target": "ipfs/hang-fds" },
-  { "target": "ipfs/http-api-docs" },
   { "target": "ipfs/interface-go-ipfs-core" },
   { "target": "ipfs/ipfs-ds-convert" },
   { "target": "ipfs/ipfs-update" },


### PR DESCRIPTION
The repository has been archived and moved to ipfs-inactive org: https://github.com/ipfs-inactive/http-api-docs