### PR TITLE
chore: remove go-ds-crdt

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,6 @@
   { "target": "ipfs/go-ds-badger" },
   { "target": "ipfs/go-ds-badger2" },
   { "target": "ipfs/go-ds-bitcask" },
-  { "target": "ipfs/go-ds-crdt" },
   { "target": "ipfs/go-ds-flatfs" },
   { "target": "ipfs/go-ds-leveldb" },
   { "target": "ipfs/go-ds-measure" },


### PR DESCRIPTION
Sorry, the release flow that was enabled replaces a "git tag; git push" operation, which takes me 1 second, with a PR, a 40 minute build and maintenance of a file with redundant information. And it does not generate an automatic changelog based on commit messages or publish a github release as I expected so it literally takes 0 work from me. All this is just adding crust that costs me time. I will re-enable this project when this changes.