### PR TITLE
make release-check pass on PRs from forked repositories

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -136,10 +136,10 @@ jobs:
       - name: Set a notice message on run
         run: |
           echo "$MESSAGE" > message.md
-          MESSAGE="${MESSAGE//'%'/'%25'}"
-          MESSAGE="${MESSAGE//$'\n'/'%0A'}"
-          MESSAGE="${MESSAGE//$'\r'/'%0D'}"
-          echo "::notice ::$MESSAGE"
+          message="${MESSAGE//'%'/'%25'}"
+          message="${message//$'\n'/'%0A'}"
+          message="${message//$'\r'/'%0D'}"
+          echo "::notice ::$message"
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Archive message
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -104,28 +104,39 @@ jobs:
           If you wish to cut a release once this PR is merged, please add the \`release\` label to this PR.
           EOF" >> $GITHUB_ENV
         if: github.base_ref != github.event.repository.default_branch
-      - name: Post output
-        uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
+      - run: |
+          echo 'MESSAGE<<EOF
+          Suggested version: `${{ env.VERSION }}`
+          Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.ref }}))
+
+          Changes in `go.mod` file(s):
+          ```diff
+          ${{ env.GOMODDIFF }}
+          ```
+
+          `gorelease` says:
+          ```
+          ${{ env.GORELEASE }}
+          ```
+
+          `gocompat` says:
+          ```
+          ${{ env.GOCOMPAT }}
+          ```
+          ${{ env.RELEASE_BRANCH_NOTE }}
+          EOF' >> $GITHUB_ENV
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+      - name: Post message on PR
+        uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
+        if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: release-check
           recreate: true
-          message: |
-            Suggested version: `${{ env.VERSION }}`
-            Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.ref }}))
-
-            Changes in `go.mod` file(s):
-            ```diff
-            ${{ env.GOMODDIFF }}
-            ```
-
-            `gorelease` says:
-            ```
-            ${{ env.GORELEASE }}
-            ```
-
-            `gocompat` says:
-            ```
-            ${{ env.GOCOMPAT }}
-            ```
-            ${{ env.RELEASE_BRANCH_NOTE }}
+          message: ${{ env.MESSAGE }}
+      - name: Set a notice message on run
+        run: |
+          MESSAGE="${MESSAGE//'%'/'%25'}"
+          MESSAGE="${MESSAGE//$'\n'/'%0A'}"
+          MESSAGE="${MESSAGE//$'\r'/'%0D'}"
+          echo "::notice ::$MESSAGE"
+        if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -30,7 +30,7 @@ jobs:
           read -ra arr <<< $(git diff-index ${{ github.event.pull_request.base.sha }} -- version.json)
           status=0
           git rev-list $VERSION &> /dev/null || status=$?
-          if [[ "${arr[4]}" == "A" && $status == 0 ]]; then 
+          if [[ "${arr[4]}" == "A" && $status == 0 ]]; then
             echo "INITIAL_RUN=true" >> $GITHUB_ENV
           fi
       - name: Install semver (node command line tool)
@@ -41,7 +41,7 @@ jobs:
         run: semver ${{ env.VERSION }} # fails if the version is not a valid semver version (e.g. v0.1 would fail)
       - name: Determine version number to compare to
         if: env.INITIAL_RUN == 'false'
-        # We need to determine the version number we want to compare to, 
+        # We need to determine the version number we want to compare to,
         # taking into account that this might be a (patch) release on a release branch.
         # Example:
         # Imagine a module that has releases for v0.1.0, v0.2.0 and v0.3.0.
@@ -71,10 +71,10 @@ jobs:
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
         run: |
           # First get the diff for the go.mod file in the root directory...
-          output=$(git diff ${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }} -- './go.mod')
+          output=$(git diff ${{ env.COMPARETO }}..HEAD -- './go.mod')
           # ... then get the diff for all go.mod files in subdirectories.
-          # Note that this command also finds go.mod files more than one level deep in the directory structure. 
-          output+=$(git diff ${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }} -- '*/go.mod')
+          # Note that this command also finds go.mod files more than one level deep in the directory structure.
+          output+=$(git diff ${{ env.COMPARETO }}..HEAD -- '*/go.mod')
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
@@ -90,7 +90,7 @@ jobs:
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
         run: |
           go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
-          output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARETO }}..${{ github.event.pull_request.head.sha }}" ./... || true)
+          output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARETO }}..HEAD" ./... || true)
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
@@ -129,4 +129,3 @@ jobs:
             ${{ env.GOCOMPAT }}
             ```
             ${{ env.RELEASE_BRANCH_NOTE }}
-

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -135,8 +135,16 @@ jobs:
           message: ${{ env.MESSAGE }}
       - name: Set a notice message on run
         run: |
+          echo "$MESSAGE" > message.md
           MESSAGE="${MESSAGE//'%'/'%25'}"
           MESSAGE="${MESSAGE//$'\n'/'%0A'}"
           MESSAGE="${MESSAGE//$'\r'/'%0D'}"
           echo "::notice ::$MESSAGE"
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Archive message
+        uses: actions/upload-artifact@v2
+        if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository
+        with:
+          name: message
+          path: message.md
+          retention-days: 1

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,3 +1,7 @@
+# This workflow cannot post sticky comments on PRs from forked repositories.
+# Instead, it outputs the message it would have posted as a workflow notice.
+# See https://github.com/protocol/.github/issues/254 for details.
+
 name: Release Checker
 on: [ workflow_call ]
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -107,7 +107,7 @@ jobs:
       - run: |
           echo 'MESSAGE<<EOF
           Suggested version: `${{ env.VERSION }}`
-          Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.ref }}))
+          Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.label }}))
 
           Changes in `go.mod` file(s):
           ```diff
@@ -145,6 +145,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository
         with:
-          name: message
+          name: message.md
           path: message.md
           retention-days: 1


### PR DESCRIPTION
This PR tries to address https://github.com/protocol/.github/issues/254

This PR makes sure that runs of `release-check` workflow succeed for PRs from forks BUT it does have to disable auto posting of the messages on such PRs. However, it makes the message easily discoverable/copyable from the workflow run. An idea for a future improvement would be to create something like `release-check-cron` that would loop over recently run `release-check`s in the repository and post comments to the PRs if they haven't been posted yet. That would be possible because a workflow that runs on cron schedule from master is allowed to have elevated privileges. 

###### Fixed issues
- replaced uses of `github.event.pull_request.head.sha` with `HEAD` since, on PRs from forked repos, the former points at a sha from the fork(which is not fetched) and the latter works as expected because it points at the local HEAD(which is the target branch fast forwarded to the head)
- replaced uses of `github.event.pull_request.head.ref` with `github.event.pull_request.head.label` because the latter also includes repository name in format of `repo_name:branch_name`(it works as expected when pasted at the and of github's compare URL)

###### Persisting issues
- workflows run from forked repos have at most read permissions on the autogenerated GitHub token(otherwise we'd have a serious security issue on our hand) so we are not able to post comment on the PR

###### Workarounds
- set notice on the `release-check` run that contains the message if running on a forked PR
- archive the message as an artifact of the `release-check` run if running on a forked PR

### Example:
**Release check run**: https://github.com/libp2p/go-doh-resolver/actions/runs/1592009640
**Message manually copied to a PR**: https://github.com/libp2p/go-doh-resolver/pull/17#issue-1083168982

