### PR TITLE
open PRs sequentially but continue updating branches in parallel

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -5,9 +5,6 @@ name: Deploy
 on:
   workflow_dispatch:
     inputs:
-      head_commit_url:
-        description: "github.event.head_commit.url of the dispatcher"
-        required: true
       targets:
         description: "List of repositories to deploy to"
         required: true

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(github.event.inputs.targets) }}
-      max-parallel: 1
+      max-parallel: 10
     env:
       TARGET_REPO_DIR: "target-repo"
       TEMPLATE_REPO_DIR: "template-repo"
@@ -30,7 +30,6 @@ jobs:
       FILES: ""
       GITHUB_USER: "web3-bot"
       GITHUB_EMAIL: "web3-bot@users.noreply.github.com"
-      DEFAULTBRANCH: ""
     name: ${{ matrix.cfg.target }}
     steps:
     - name: Checkout ${{ matrix.cfg.target }}
@@ -45,11 +44,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
-    - name: determine GitHub default branch
-      working-directory: ${{ env.TARGET_REPO_DIR }}
-      run: |
-        defaultbranch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
-        echo "DEFAULTBRANCH=$defaultbranch" >> $GITHUB_ENV
     - name: git config
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: |
@@ -111,16 +105,13 @@ jobs:
           # add DO NOT EDIT header
           tmp=$(mktemp)
           cat $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/header.yml $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f > $tmp
-          # replace $default-branch with this repo's GitHub default branch
-          sed -i "s:\$default-branch:${{ env.DEFAULTBRANCH }}:g" $tmp
-          mv $tmp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f
           # create commit, if necessary
           commit_msg=""
           if [[ ! -f "$TARGET_REPO_DIR/$f" ]]; then
             echo "First deployment.\n"
             commit_msg="add $f"
           else
-            status=$(cmp --silent $TARGET_REPO_DIR/$f $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f; echo $?)
+            status=$(cmp --silent $TARGET_REPO_DIR/$f $tmp; echo $?)
             if [[ $status -ne 0 ]]; then
               echo "Update needed."
               commit_msg="update $f"
@@ -129,26 +120,19 @@ jobs:
               continue
             fi
           fi
-          dir="$TARGET_REPO_DIR/"$(dirname $f)
-          mkdir -p $dir
-          cp $TEMPLATE_REPO_DIR/$TEMPLATE_DIR/$f $dir
+          mkdir -p "$TARGET_REPO_DIR/$(dirname $f)"
+          mv $tmp $TARGET_REPO_DIR/$f
           pushd $TARGET_REPO_DIR > /dev/null
           git add $f
           git commit -m "$commit_msg"
           popd > /dev/null
         done
-    - name: Check if we need to create a PR
+    - name: Check if we need to update the branch
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: echo "NEEDS_UPDATE=$(git rev-list HEAD...origin/$(git rev-parse --abbrev-ref HEAD) --ignore-submodules --count 2> /dev/null || echo 1)" >> $GITHUB_ENV
-    - name: Create Pull Request
+    - name: Force push ${{ env.GITHUB_USER }}/sync branch
       if: ${{ env.NEEDS_UPDATE != 0 }}
-      uses: peter-evans/create-pull-request@83dbed188f76ab04433c639ec214df65e26bc15c # https://github.com/peter-evans/create-pull-request/pull/856
-      with:
-        path: ${{ env.TARGET_REPO_DIR }}
-        title: "sync: update CI config files"
-        body: Syncing to commit ${{ github.event.inputs.head_commit_url }}.
-        token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-        committer: ${{ env.GITHUB_USER }} <${{ env.GITHUB_EMAIL }}>
-        author: ${{ env.GITHUB_USER }} <${{ env.GITHUB_EMAIL }}>
-        branch: ${{ env.GITHUB_USER }}/sync
-        delete-branch: true
+      working-directory: ${{ env.TARGET_REPO_DIR }}
+      run: |
+        git checkout -B ${{ env.GITHUB_USER }}/sync
+        git push origin ${{ env.GITHUB_USER }}/sync -f

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,4 +1,4 @@
-# Trigger the execution of copy-workflow.yml, in batches of 256 repositories.
+# Trigger the execution of copy workflow in batches.
 # This workflow is needed since GitHub Actions limits the matrix size to 256 jobs.
 # We use one job per repository per batch.
 
@@ -8,13 +8,13 @@ on:
 
 env:
   # Number of repositories in a batch.
-  # Deployment jobs in the same batch are run sequentially.
+  # Matrix jobs within a copy workflow run are run in parallel.
   # 256 is the upper limit on the number of matrix jobs.
-  # Batching too many targets together can result in
+  # Batching too many repositories together can result in
   #  could not create workflow dispatch event: HTTP 422: inputs are too large.
-  #  when issueing dispatch_workflow event.
+  # This value should be higher than max-parallel in copy workflow.
   MAX_REPOS_PER_WORKFLOW: 100
-  # Number of seconds to wait before starting to watch workflow status.
+  # Number of seconds to wait before starting to watch copy workflow run.
   # Unfortunately, the interval on the watch is not configurable.
   # The delay helps us save on GH API requests.
   WORKFLOW_COMPLETION_CHECK_DELAY: 60
@@ -62,8 +62,9 @@ jobs:
         #     {"target": "repo2", "files": [".github/workflows/go-check.yml", ".github/workflows/go-test.yml"]}
         #   ]
         #
-        # The triggered copy-workflow jobs use that final array as their matrix.
-        # Since max-parallel here is 1, we'll end up with at most copy-workflow@max-parallel + 1 parallel jobs.
+        # The triggered copy workflow runs use that final array as their matrix.
+        # Since max-parallel here is 1, we'll end up with at most max-parallel from copy workflow + 1 parallel jobs.
+        # 20 is the upper limit on parallel jobs on a free plan.
         cfg: ${{ fromJson(needs.matrix.outputs.batches) }}
       max-parallel: 1
     env:
@@ -72,20 +73,19 @@ jobs:
       WORKFLOW_REPO: protocol/.github
     steps:
       - id: dispatch
-        name: Dispatch workflow
+        name: Dispatch copy workflow
         run: |
           start_date="$(date +%s)"
           # 2 toJson calls are needed to turn the array of targets into a string
           echo '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}' | jq -c '.' | gh workflow run "${{ env.WORKFLOW_YML }}" --ref "${{ github.ref }}" --repo "${{ env.WORKFLOW_REPO }}" --json
           echo "::set-output name=start_date::$start_date"
       - id: run
-        name: Wait for run to start
+        name: Wait for copy workflow run to start
         run: |
-          # checks every 3 seconds until the most recent run's created_at
-          # is later than the time this job started
+          # checks every 3 seconds until the most recent copy workflow run's created_at is later than this job's start_date
           while sleep 3; do
             run="$(gh api "/repos/${{ env.WORKFLOW_REPO }}/actions/workflows/${{ env.WORKFLOW_YML }}/runs?per_page=1" --jq '.workflow_runs[0]')"
-            # nothing to check if no run was returned
+            # nothing to check if no copy workflow run was returned
             if [[ ! -z "$run" ]]; then
               run_start_date="$(date --date="$(jq -r '.created_at' <<< "$run")" +%s)"
               if [[ "$run_start_date" > "${{ steps.dispatch.outputs.start_date }}" ]]; then
@@ -94,32 +94,34 @@ jobs:
               fi
             fi
           done
-      - name: Wait for run to complete
+      - name: Wait for copy workflow run to complete
         run: |
-          # it is not expected for the run to finish immediately so we add delay before checking on it
+          # delays checking copy workflow's run status to save on GH API requests
           sleep ${{ env.WORKFLOW_COMPLETION_CHECK_DELAY }}
-          # refreshes run status every 3 seconds until completion
-          # redirecting the stdout to /dev/null because this call is very chatty
-          # interval is not configurable
+
+          # checks every 3 seconds until the copy workflow run's status is completed
+          # redirects the stdout to /dev/null because it is very chatty
           gh run watch "${{ steps.run.outputs.id }}" --repo "${{ env.WORKFLOW_REPO }}" > /dev/null
       - id: jobs
-        name: Retrieve jobs from the run
+        name: Find copy workflow jobs that pushed changes
         env:
           STEP_NAME: 'Force push web3-bot/sync branch'
         run: |
           targets=()
           page=1
+          # 100 is the upper limit on number of jobs returned per page
           per_page=100
           while jobs="$(gh api -X GET "/repos/${{ env.WORKFLOW_REPO }}/actions/runs/${{ steps.run.outputs.id }}/jobs" -f page="$page" -f per_page="$per_page")"; do
-            # add jobs that successfully executed $STEP_NAME to targets
+            # adds copy workflow jobs that successfully executed $STEP_NAME to targets
             targets+=($(jq -r '.jobs[] | select(.steps[] | select(.name == "${{ env.STEP_NAME }}") and select(.conclusion == "success")) | .name' <<< "$jobs" ))
+            # exits when all the copy workflow jobs have been processed
             if (( page * per_page >= $(jq -r '.total_count' <<< "$jobs") )); then
               break
             fi
             (( page+=1 ))
           done
           echo "::set-output name=targets::$(jq -nc '$ARGS.positional' --args ${targets[@]})"
-      - name: Create PRs if needed
+      - name: Create PRs in targets that need it
         env:
           PR_TITLE: 'sync: update CI config files'
           PR_BODY: 'Syncing to commit ${{ github.event.head_commit.url }}.'
@@ -127,7 +129,7 @@ jobs:
         run: |
           for target in $(jq -r '.[]' <<< ${{ toJson(steps.jobs.outputs.targets) }}); do
             base="$(gh api "/repos/${target}" --jq '.default_branch')"
-            # try to create a PR
+            # tries to create a PR in target
             if result="$(gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base")"; then
               echo "$result"
               echo "::debug::Successfully created a PR for '$target'"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -10,7 +10,10 @@ env:
   # Number of repositories in a batch.
   # Deployment jobs in the same batch are run sequentially.
   # 256 is the upper limit on the number of matrix jobs.
-  MAX_REPOS_PER_WORKFLOW: 256
+  # Batching too many targets together can result in
+  #  could not create workflow dispatch event: HTTP 422: inputs are too large.
+  #  when issueing dispatch_workflow event.
+  MAX_REPOS_PER_WORKFLOW: 100
 
 jobs:
   matrix:
@@ -72,13 +75,13 @@ jobs:
         run: |
           start_date="$(date +%s)"
           # 2 toJson calls are needed to turn the array of targets into a string
-          echo '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}' | gh workflow run "${{ env.WORKFLOW_YML }}" --ref "${{ github.ref }}" --repo "${{ env.WORKFLOW_REPO }}" --json
+          echo '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}' | jq -c '.' | gh workflow run "${{ env.WORKFLOW_YML }}" --ref "${{ github.ref }}" --repo "${{ env.WORKFLOW_REPO }}" --json
           echo "::set-output name=start_date::$start_date"
       - id: run
         name: Wait for run to start
         run: |
           # checks every 3 seconds until the most recent workflow's age
-          # is smaller than the time passed since this job has started
+          #  is smaller than the time passed since this job has started
           while sleep 3; do
             # output format: STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE
             run="$(gh run list --workflow="${{ env.WORKFLOW_YML }}" --repo "${{ env.WORKFLOW_REPO }}" --limit=1)"
@@ -100,9 +103,9 @@ jobs:
       - name: Wait for run to complete
         run: |
           # refreshes run status every 3 seconds until completion
-          # we're redirecting the stdout to /dev/null because this call is very chatty
-          # we might want to consider writing this check ourselves to make the interval longer
-          gh run watch "$run_id" --repo "${{ env.WORKFLOW_REPO }}" > /dev/null
+          # redirecting the stdout to /dev/null because this call is very chatty
+          # interval is not configurable
+          gh run watch "${{ steps.run.outputs.id }}" --repo "${{ env.WORKFLOW_REPO }}" > /dev/null
       - id: jobs
         name: Retrieve jobs from the run
         env:
@@ -111,10 +114,13 @@ jobs:
           targets=()
           page=1
           per_page=100
-          while jobs="$(gh api -X GET "/repos/${{ env.WORKFLOW_REPO }}/actions/runs/$run_id/jobs" -f page="$page" -f per_page="$per_page")"; do
+          while jobs="$(gh api -X GET "/repos/${{ env.WORKFLOW_REPO }}/actions/runs/${{ steps.run.outputs.id }}/jobs" -f page="$page" -f per_page="$per_page")"; do
             # add jobs that successfully executed $STEP_NAME to targets
             targets+=($(jq -r '.jobs[] | select(.steps[] | select(.name == "${{ env.STEP_NAME }}") and select(.conclusion == "success")) | .name' <<< "$jobs" ))
-            per_page+=1
+            if (( page * per_page >= $(jq -r '.total_count' <<< "$jobs") )); then
+              break
+            fi
+            (( page+=1 ))
           done
           echo "::set-output name=targets::$(jq -nc '$ARGS.positional' --args ${targets[@]})"
       - name: Create PRs if needed
@@ -126,11 +132,11 @@ jobs:
           for target in $(jq -r '.[]' <<< ${{ toJson(steps.jobs.outputs.targets) }}); do
             base="$(gh api "/repos/${target}" --jq '.default_branch')"
             # try to create a PR
-            if gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base"; then
-              echo ""
-              echo "\n::debug::Successfully created a PR for '$target'"
+            if result="$(gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base")"; then
+              echo "$result"
+              echo "::debug::Successfully created a PR for '$target'"
             else
-              echo ""
+              echo "$result"
               echo "::error ::Failed to create a PR for '$target'"
             fi
             sleep 3

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -73,26 +73,29 @@ jobs:
           PR_BRANCH: 'web3-bot/sync'
         run: |
           echo "::group::Dispatch workflow"
-          # record the time before the workflow dispatch even has been issued
+          # record the time before the workflow dispatch is issued
+          # it will be used to find the id of the run this job triggered
           start="$(date +%s)"
           echo "$WORKFLOW_JSON" | gh workflow run "$WORKFLOW_YML" --ref "$WORKFLOW_REF" --repo "$WORKFLOW_REPO" --json
           echo "::endgroup::"
 
           echo "::group::Wait for workflow to start"
-          # checks every 3 seconds until the most recent run of the workflow has started after the dispatch
+          # checks every 3 seconds until the most recent workflow's age
+          # is smaller than the time passed since this job has started
           while sleep 3; do
-            # prints 'STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE'
+            # output format: STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE
             run="$(gh run list --workflow="$WORKFLOW_YML" --repo "$WORKFLOW_REPO" --limit=1)"
-            # will skip this part if there are no runs of the workflow yet
+            # nothing to check if no run was returned
             if [[ ! -z "$run" ]]; then
+              # retrieve age and format it for use with date
               age="$(echo "$run" | cut -f9)"
               age="$(echo "$age" | sed 's/s$/ seconds/')"
               age="$(echo "$age" | sed 's/m$/ minutes/')"
               age="$(echo "$age" | sed 's/h$/ hours/')"
               age="$(echo "$age" | sed 's/d$/ days/')"
               # if the run happened more than a month ago, age is the exact date
-              age="$(date -d "-$age" +%s)"
-              if [[ "$age" > "$start" ]]; then
+              run_start="$(date -d "-$age" +%s)"
+              if [[ "$run_start" > "$start" ]]; then
                 run_id="$(echo "$run" | cut -f7)"
                 break
               fi
@@ -103,17 +106,22 @@ jobs:
           echo "::group::Wait for workflow to complete"
           # refreshes run status every 3 seconds until completion
           # we're redirecting the stdout to /dev/null because this call is very chatty
-          # we might want to consider writing out this check ourselves to make the interval longer
+          # we might want to consider writing this check ourselves to make the interval longer
           gh run watch "$run_id" --repo "$WORKFLOW_REPO" > /dev/null
           echo "::endgroup::"
 
           echo "::group::Create PRs if needed"
-          # looking for lines like '✓ $job_name in $job_elapsed (ID $job_id)' and looping over '$job_name $job_id'
+          # looking for lines like '✓ $job_name in $job_elapsed (ID $job_id)'
+          # looping over '$job_name $job_id'
+          # alternatively
+          #   gh api "/repos/$WORKFLOW_REPO/actions/runs/$run_id/jobs" --jq '.jobs[] | select(.steps[] | select(.name == "$STEP_NAME") and select(.conclusion == "success")) | .name'
+          # returns a list of jobs that successfully executed $STEP NAME
+          # but it can only return 100 results at a time so we'd have to deal with pagination
           gh run view "$run_id" --repo "$WORKFLOW_REPO" | sed -nr 's/✓ (.+) in .+ \(ID (.+)\)/\1\t\2/p' | while read line; do
             job_name="$(echo "$line" | cut -f1)"
             job_id="$(echo "$line" | cut -f2)"
 
-            # check if step called $STEP_NAME has been executed
+            # check if the step called $STEP_NAME was executed in the job
             if gh run view --job "$job_id" --repo "$WORKFLOW_REPO" | grep -q "✓ $STEP_NAME"; then
               base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
               # try to create a PR and sleep for a while afterwards

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -111,29 +111,31 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Create PRs if needed"
-          # looking for lines like '✓ $job_name in $job_elapsed (ID $job_id)'
-          # looping over '$job_name $job_id'
-          # alternatively
-          #   gh api "/repos/$WORKFLOW_REPO/actions/runs/$run_id/jobs" --jq '.jobs[] | select(.steps[] | select(.name == "$STEP_NAME") and select(.conclusion == "success")) | .name'
-          # returns a list of jobs that successfully executed $STEP NAME
-          # but it can only return 100 results at a time so we'd have to deal with pagination
-          gh run view "$run_id" --repo "$WORKFLOW_REPO" | sed -nr 's/✓ (.+) in .+ \(ID (.+)\)/\1\t\2/p' | while read line; do
-            job_name="$(echo "$line" | cut -f1)"
-            job_id="$(echo "$line" | cut -f2)"
-
-            # check if the step called $STEP_NAME was executed in the job
-            if gh run view --job "$job_id" --repo "$WORKFLOW_REPO" | grep -q "✓ $STEP_NAME"; then
-              base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
-              # try to create a PR and sleep for a while afterwards
-              if gh api "/repos/$job_name/pulls" -f title="$PR_TITLE" -f body="$PR_BODY" -f head="$PR_BRANCH" -f base="$base"; then
-                echo ""
-                echo "::debug::Successfully created a PR for '$job_name'"
-              else
-                echo ""
-                echo "::error ::Failed to create a PR for '$job_name'"
-              fi
-              sleep 3
+          targets=()
+          page=1
+          per_page=100
+          # retrieve all the matrix jobs
+          while jobs="$(gh api -X GET "/repos/$WORKFLOW_REPO/actions/runs/$run_id/jobs" -f page="$page" -f per_page="$per_page")"; do
+            total_count=$(jq -c '.total_count' <<< "$jobs")
+            # add jobs that successfully executed $STEP_NAME to targets
+            targets+=($(jq -r '.jobs[] | select(.steps[] | select(.name == "$STEP_NAME") and select(.conclusion == "success")) | .name' <<< "$jobs" ))
+            if (( page * per_page < total_count )); then
+              per_page+=1
+            else
+              break
             fi
+          done
+          for target in "${targets[@]}"; do
+            base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
+            # try to create a PR and sleep for a while afterwards
+            if gh api "/repos/$job_name/pulls" -f title="$PR_TITLE" -f body="$PR_BODY" -f head="$PR_BRANCH" -f base="$base"; then
+              echo ""
+              echo "\n::debug::Successfully created a PR for '$job_name'"
+            else
+              echo ""
+              echo "::error ::Failed to create a PR for '$job_name'"
+            fi
+            sleep 3
           done
           echo "::endgroup::"
         shell: bash

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-          WORKFLOW_REF: ${{ env.GITHUB_REF }}
+          WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_YML: copy-workflow.yml
           WORKFLOW_REPO: protocol/.github
           # 2 toJson calls are needed to turn the array of targets into a string

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -75,7 +75,7 @@ jobs:
           echo "::group::Dispatch workflow"
           # record the time before the workflow dispatch even has been issued
           start="$(date +%s)"
-          echo "$WORKFLOW_JSON" | gh workflow run "$WORKFLOW_YML" --ref "$WORKFLOW_BRANCH" --repo "$WORKFLOW_REPO" --json
+          echo "$WORKFLOW_JSON" | gh workflow run "$WORKFLOW_YML" --ref "$WORKFLOW_REF" --repo "$WORKFLOW_REPO" --json
           echo "::endgroup::"
 
           echo "::group::Wait for workflow to start"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -80,22 +80,15 @@ jobs:
       - id: run
         name: Wait for run to start
         run: |
-          # checks every 3 seconds until the most recent workflow's age
-          #  is smaller than the time passed since this job has started
+          # checks every 3 seconds until the most recent run's created_at
+          # is later than the time this job started
           while sleep 3; do
-            # output format: STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE
-            run="$(gh run list --workflow="${{ env.WORKFLOW_YML }}" --repo "${{ env.WORKFLOW_REPO }}" --limit=1)"
-
+            run="$(gh api "/repos/${{ env.WORKFLOW_REPO }}/actions/workflows/${{ env.WORKFLOW_YML }}/runs?per_page=1" --jq '.workflow_runs[0]')"
             # nothing to check if no run was returned
             if [[ ! -z "$run" ]]; then
-              # retrieve age and format it for use with date
-              # if the run happened more than a month ago, age is the exact date
-              age="$(echo "$run" | cut -f9 | sed 's/s$/ seconds/' | sed 's/m$/ minutes/' | sed 's/h$/ hours/' |  sed 's/d$/ days/')"
-
-
-              run_start_date="$(date -d "-$age" +%s)"
+              run_start_date="$(date --date="$(jq -r '.created_at' <<< "$run")" +%s)"
               if [[ "$run_start_date" > "${{ steps.dispatch.outputs.start_date }}" ]]; then
-                echo "::set-output name=id::$(echo "$run" | cut -f7)"
+                echo "::set-output name=id::$(jq -r '.id' <<< "$run")"
                 break
               fi
             fi

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,6 +1,6 @@
-# Trigger the execution of copy-workflow.yml, in batches of 8 repositories.
+# Trigger the execution of copy-workflow.yml, in batches of 256 repositories.
 # This workflow is needed since GitHub Actions limits the matrix size to 256 jobs.
-# We use one job per repository per file.
+# We use one job per repository per batch.
 
 on:
   push:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -131,8 +131,15 @@ jobs:
             base="$(gh api "/repos/${target}" --jq '.default_branch')"
             # tries to create a PR in target
             if result="$(gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base")"; then
-              echo "$result"
-              echo "::debug::Successfully created a PR for '$target'"
+              echo "Successfully created a PR for '$target'"
+            elif [[ "$(jq -r '.errors[0].message' <<< "$result")" == 'A pull request already exists'* ]]; then
+              number="$(gh api "/repos/$target/pulls?head=${{ env.PR_BRANCH }}&per_page=1&state=open" --jq '.[0].number')"
+              if result="$(gh api -X PATCH "/repos/$target/pulls/$number" -f body="${{ env.PR_BODY }}" -f base="$base")"; then
+                echo "Successfully updated the PR for '$target'"
+              else
+                echo "$result"
+                echo "::error ::Failed to update the PR for '$target'"
+              fi
             else
               echo "$result"
               echo "::error ::Failed to create a PR for '$target'"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -14,6 +14,10 @@ env:
   #  could not create workflow dispatch event: HTTP 422: inputs are too large.
   #  when issueing dispatch_workflow event.
   MAX_REPOS_PER_WORKFLOW: 100
+  # Number of seconds to wait before starting to watch workflow status.
+  # Unfortunately, the interval on the watch is not configurable.
+  # The delay helps us save on GH API requests.
+  WORKFLOW_COMPLETION_CHECK_DELAY: 60
 
 jobs:
   matrix:
@@ -66,9 +70,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
       WORKFLOW_YML: copy-workflow.yml
       WORKFLOW_REPO: protocol/.github
-    defaults:
-      run:
-        shell: bash
     steps:
       - id: dispatch
         name: Dispatch workflow
@@ -95,6 +96,8 @@ jobs:
           done
       - name: Wait for run to complete
         run: |
+          # it is not expected for the run to finish immediately so we add delay before checking on it
+          sleep ${{ env.WORKFLOW_COMPLETION_CHECK_DELAY }}
           # refreshes run status every 3 seconds until completion
           # redirecting the stdout to /dev/null because this call is very chatty
           # interval is not configurable

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -9,13 +9,12 @@ on:
 env:
   # Number of repositories in a batch.
   # Deployment jobs in the same batch are run sequentially.
-  # With ~180 repos, this means we'll run around 9 instances of the copy workflow in parallel.
-  # This is (hopefully) sufficient to prevent us from triggering GitHub Action's abuse detection mechanism.
-  MAX_REPOS_PER_WORKFLOW: 20
+  # 256 is the upper limit on the number of matrix jobs.
+  MAX_REPOS_PER_WORKFLOW: 256
 
 jobs:
   matrix:
-    name: Trigger copy workflows
+    name: Batch targets
     runs-on: ubuntu-latest
     outputs:
       batches: ${{ steps.set-matrix.outputs.batches }}
@@ -42,6 +41,7 @@ jobs:
           echo "::set-output name=batches::$batches"
   dispatch:
     needs: [ matrix ]
+    name: Dispatch copy workflow(batch ${{ matrix.cfg.key }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -51,18 +51,78 @@ jobs:
         # For each "dispatch" job, matrix.cfg.value is an array, like:
         #
         #   [
-        #     {"target": "repo1", "files": [".github/workflows/go-check.yml"]}, 
+        #     {"target": "repo1", "files": [".github/workflows/go-check.yml"]},
         #     {"target": "repo2", "files": [".github/workflows/go-check.yml", ".github/workflows/go-test.yml"]}
         #   ]
         #
         # The triggered copy-workflow jobs use that final array as their matrix.
-        # As such, we'll end up with one copy-workflow parallel job per target.
+        # Since max-parallel here is 1, we'll end up with at most copy-workflow@max-parallel + 1 parallel jobs.
         cfg: ${{ fromJson(needs.matrix.outputs.batches) }}
-    name: Start copy workflow (batch ${{ matrix.cfg.key }})
+      max-parallel: 1
     steps:
-      - uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1.1.0
-        with:
-          workflow: "Deploy" # "name" attribute of copy-workflow.yml
-          token: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-          # double toJson on matrix.cfg.value is here on purpose
-          inputs: '{ "head_commit_url": ${{ toJson(github.event.head_commit.url) }}, "targets": ${{ toJson(toJson(matrix.cfg.value)) }} }'
+      - env:
+          GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
+          WORKFLOW_REF: ${{ env.GITHUB_REF }}
+          WORKFLOW_YML: copy-workflow.yml
+          WORKFLOW_REPO: protocol/.github
+          # 2 toJson calls are needed to turn the array of targets into a string
+          WORKFLOW_JSON: '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}'
+          STEP_NAME: 'Force push web3-bot/sync branch'
+          PR_TITLE: 'sync: update CI config files'
+          PR_BODY: 'Syncing to commit ${{ github.event.head_commit.url }}.'
+          PR_BRANCH: 'web3-bot/sync'
+        run: |
+          echo "::group::Dispatch workflow"
+          # record the time before the workflow dispatch even has been issued
+          start="$(date +%s)"
+          echo "$WORKFLOW_JSON" | gh workflow run "$WORKFLOW_YML" --ref "$WORKFLOW_BRANCH" --repo "$WORKFLOW_REPO" --json
+          echo "::endgroup::"
+
+          echo "::group::Wait for workflow to start"
+          # checks every 3 seconds until the most recent run of the workflow has started after the dispatch
+          while sleep 3; do
+            # prints 'STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE'
+            run="$(gh run list --workflow="$WORKFLOW_YML" --repo "$WORKFLOW_REPO" --limit=1)"
+            # will skip this part if there are no runs of the workflow yet
+            if [[ ! -z "$run" ]]; then
+              age="$(echo "$run" | cut -f9)"
+              age="$(echo "$age" | sed 's/s$/ seconds/')"
+              age="$(echo "$age" | sed 's/m$/ minutes/')"
+              age="$(echo "$age" | sed 's/h$/ hours/')"
+              age="$(echo "$age" | sed 's/d$/ days/')"
+              # if the run happened more than a month ago, age is the exact date
+              age="$(date -d "-$age" +%s)"
+              if [[ "$age" > "$start" ]]; then
+                run_id="$(echo "$run" | cut -f7)"
+                break
+              fi
+            fi
+          done
+          echo "::endgroup::"
+
+          echo "::group::Wait for workflow to complete"
+          # refreshes run status every 3 seconds until completion
+          # we're redirecting the stdout to /dev/null because this call is very chatty
+          # we might want to consider writing out this check ourselves to make the interval longer
+          gh run watch "$run_id" --repo "$WORKFLOW_REPO" > /dev/null
+          echo "::endgroup::"
+
+          echo "::group::Create PRs if needed"
+          # looking for lines like '✓ $job_name in $job_elapsed (ID $job_id)' and looping over '$job_name $job_id'
+          gh run view "$run_id" --repo "$WORKFLOW_REPO" | sed -nr 's/✓ (.+) in .+ \(ID (.+)\)/\1\t\2/p' | while read line; do
+            job_name="$(echo "$line" | cut -f1)"
+            job_id="$(echo "$line" | cut -f2)"
+
+            # check if step called $STEP_NAME has been executed
+            if gh run view --job "$job_id" --repo "$WORKFLOW_REPO" | grep -q "✓ $STEP_NAME"; then
+              # try to create a PR and sleep for a while afterwards
+              if gh pr create --body "$PR_BODY" --head "$PR_BRANCH" --title "$PR_TITLE" --repo "$job_name"; then
+                echo "::debug::Successfully created a PR for '$job_name'"
+              else
+                echo "::error ::Failed to create a PR for '$job_name'"
+              fi
+              sleep 3
+            fi
+          done
+          echo "::endgroup::"
+        shell: bash

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -115,8 +115,9 @@ jobs:
 
             # check if step called $STEP_NAME has been executed
             if gh run view --job "$job_id" --repo "$WORKFLOW_REPO" | grep -q "✓ $STEP_NAME"; then
+              base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
               # try to create a PR and sleep for a while afterwards
-              if gh pr create --body "$PR_BODY" --head "$PR_BRANCH" --title "$PR_TITLE" --repo "$job_name"; then
+              if gh api "/repos/$job_name/pulls" -f title="$PR_TITLE" -f body="$PR_BODY" -f head="$PR_BRANCH" -f base="$base"; then
                 echo "::debug::Successfully created a PR for '$job_name'"
               else
                 echo "::error ::Failed to create a PR for '$job_name'"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -118,8 +118,10 @@ jobs:
               base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
               # try to create a PR and sleep for a while afterwards
               if gh api "/repos/$job_name/pulls" -f title="$PR_TITLE" -f body="$PR_BODY" -f head="$PR_BRANCH" -f base="$base"; then
+                echo ""
                 echo "::debug::Successfully created a PR for '$job_name'"
               else
+                echo ""
                 echo "::error ::Failed to create a PR for '$job_name'"
               fi
               sleep 3

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -59,83 +59,79 @@ jobs:
         # Since max-parallel here is 1, we'll end up with at most copy-workflow@max-parallel + 1 parallel jobs.
         cfg: ${{ fromJson(needs.matrix.outputs.batches) }}
       max-parallel: 1
+    env:
+      GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
+      WORKFLOW_YML: copy-workflow.yml
+      WORKFLOW_REPO: protocol/.github
+    defaults:
+      run:
+        shell: bash
     steps:
-      - env:
-          GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
-          WORKFLOW_REF: ${{ github.ref }}
-          WORKFLOW_YML: copy-workflow.yml
-          WORKFLOW_REPO: protocol/.github
-          # 2 toJson calls are needed to turn the array of targets into a string
-          WORKFLOW_JSON: '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}'
-          STEP_NAME: 'Force push web3-bot/sync branch'
-          PR_TITLE: 'sync: update CI config files'
-          PR_BODY: 'Syncing to commit ${{ github.event.head_commit.url }}.'
-          PR_BRANCH: 'web3-bot/sync'
+      - id: dispatch
+        name: Dispatch workflow
         run: |
-          echo "::group::Dispatch workflow"
-          # record the time before the workflow dispatch is issued
-          # it will be used to find the id of the run this job triggered
-          start="$(date +%s)"
-          echo "$WORKFLOW_JSON" | gh workflow run "$WORKFLOW_YML" --ref "$WORKFLOW_REF" --repo "$WORKFLOW_REPO" --json
-          echo "::endgroup::"
-
-          echo "::group::Wait for workflow to start"
+          start_date="$(date +%s)"
+          # 2 toJson calls are needed to turn the array of targets into a string
+          echo '{"targets":${{ toJson(toJson(matrix.cfg.value)) }}}' | gh workflow run "${{ env.WORKFLOW_YML }}" --ref "${{ github.ref }}" --repo "${{ env.WORKFLOW_REPO }}" --json
+          echo "::set-output name=start_date::$start_date"
+      - id: run
+        name: Wait for run to start
+        run: |
           # checks every 3 seconds until the most recent workflow's age
           # is smaller than the time passed since this job has started
           while sleep 3; do
             # output format: STATUS NAME WORKFLOW BRANCH EVENT ID ELAPSED AGE
-            run="$(gh run list --workflow="$WORKFLOW_YML" --repo "$WORKFLOW_REPO" --limit=1)"
+            run="$(gh run list --workflow="${{ env.WORKFLOW_YML }}" --repo "${{ env.WORKFLOW_REPO }}" --limit=1)"
+
             # nothing to check if no run was returned
             if [[ ! -z "$run" ]]; then
               # retrieve age and format it for use with date
-              age="$(echo "$run" | cut -f9)"
-              age="$(echo "$age" | sed 's/s$/ seconds/')"
-              age="$(echo "$age" | sed 's/m$/ minutes/')"
-              age="$(echo "$age" | sed 's/h$/ hours/')"
-              age="$(echo "$age" | sed 's/d$/ days/')"
               # if the run happened more than a month ago, age is the exact date
-              run_start="$(date -d "-$age" +%s)"
-              if [[ "$run_start" > "$start" ]]; then
-                run_id="$(echo "$run" | cut -f7)"
+              age="$(echo "$run" | cut -f9 | sed 's/s$/ seconds/' | sed 's/m$/ minutes/' | sed 's/h$/ hours/' |  sed 's/d$/ days/')"
+
+
+              run_start_date="$(date -d "-$age" +%s)"
+              if [[ "$run_start_date" > "${{ steps.dispatch.outputs.start_date }}" ]]; then
+                echo "::set-output name=id::$(echo "$run" | cut -f7)"
                 break
               fi
             fi
           done
-          echo "::endgroup::"
-
-          echo "::group::Wait for workflow to complete"
+      - name: Wait for run to complete
+        run: |
           # refreshes run status every 3 seconds until completion
           # we're redirecting the stdout to /dev/null because this call is very chatty
           # we might want to consider writing this check ourselves to make the interval longer
-          gh run watch "$run_id" --repo "$WORKFLOW_REPO" > /dev/null
-          echo "::endgroup::"
-
-          echo "::group::Create PRs if needed"
+          gh run watch "$run_id" --repo "${{ env.WORKFLOW_REPO }}" > /dev/null
+      - id: jobs
+        name: Retrieve jobs from the run
+        env:
+          STEP_NAME: 'Force push web3-bot/sync branch'
+        run: |
           targets=()
           page=1
           per_page=100
-          # retrieve all the matrix jobs
-          while jobs="$(gh api -X GET "/repos/$WORKFLOW_REPO/actions/runs/$run_id/jobs" -f page="$page" -f per_page="$per_page")"; do
-            total_count=$(jq -c '.total_count' <<< "$jobs")
+          while jobs="$(gh api -X GET "/repos/${{ env.WORKFLOW_REPO }}/actions/runs/$run_id/jobs" -f page="$page" -f per_page="$per_page")"; do
             # add jobs that successfully executed $STEP_NAME to targets
-            targets+=($(jq -r '.jobs[] | select(.steps[] | select(.name == "$STEP_NAME") and select(.conclusion == "success")) | .name' <<< "$jobs" ))
-            if (( page * per_page < total_count )); then
-              per_page+=1
-            else
-              break
-            fi
+            targets+=($(jq -r '.jobs[] | select(.steps[] | select(.name == "${{ env.STEP_NAME }}") and select(.conclusion == "success")) | .name' <<< "$jobs" ))
+            per_page+=1
           done
-          for target in "${targets[@]}"; do
-            base="$(gh api "/repos/${job_name}" --jq '.default_branch')"
-            # try to create a PR and sleep for a while afterwards
-            if gh api "/repos/$job_name/pulls" -f title="$PR_TITLE" -f body="$PR_BODY" -f head="$PR_BRANCH" -f base="$base"; then
+          echo "::set-output name=targets::$(jq -nc '$ARGS.positional' --args ${targets[@]})"
+      - name: Create PRs if needed
+        env:
+          PR_TITLE: 'sync: update CI config files'
+          PR_BODY: 'Syncing to commit ${{ github.event.head_commit.url }}.'
+          PR_BRANCH: 'web3-bot/sync'
+        run: |
+          for target in $(jq -r '.[]' <<< ${{ toJson(steps.jobs.outputs.targets) }}); do
+            base="$(gh api "/repos/${target}" --jq '.default_branch')"
+            # try to create a PR
+            if gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base"; then
               echo ""
-              echo "\n::debug::Successfully created a PR for '$job_name'"
+              echo "\n::debug::Successfully created a PR for '$target'"
             else
               echo ""
-              echo "::error ::Failed to create a PR for '$job_name'"
+              echo "::error ::Failed to create a PR for '$target'"
             fi
             sleep 3
           done
-          echo "::endgroup::"
-        shell: bash


### PR DESCRIPTION
This PR tries to address https://github.com/protocol/.github/issues/36.

## Prerequisites

It includes the changes introduced in https://github.com/protocol/.github/pull/239 so this PR is going to be ready for review once that PR is merged.

## Description

When deploying changes to all the repositories, we're hitting a [secondary rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits) due to opening too many PRs too quickly. I believe the only problematic call involved in the process is the [Create a Pull Request](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request) API call. The documentation mentions that hitting the endpoint too quickly may lead to hitting the limit.

That's why I propose to reorganise the `dispatch`/`copy-workflow` procedure in the following way:
1. Prepare batches of up to 256 targets.
1. For each batch(sequentially):
    1. Trigger `copy-workflow` with the batch; for each target(in up to 20 parallel jobs):
        1. Checkout the default branch
        1. Copy files as instructed by the config
        1. Check if there are any changes
        1. Push the changes to remote `web3-bot/sync` branch IF there are any changes
    1. Wait for the triggered `copy-workflow` to complete
    1. Find all the matrix jobs from the `copy-workflow` that pushed changes to remote `web3-bot/sync` branch
    1. For all the found matrix jobs(sequentially):
        1. Create a PR
        1. Sleep for 3 seconds

The main idea here is to do as much of parallelisable work inside `copy-workflow` and parallelise it as much as possible. That only leaves the PR creation calls to be executed sequentially. Furthermore, by executing PR creation calls conditionally(only if needed) we're able to keep the runtime when we only update a handful of repos small.

We could further optimise this procedure by performing the PR creation part in parallel to `copy-workflow` execution. I think that would be possible because the `copy-workflow` doesn't execute any GH API calls. However, I propose that we postpone any work in this direction until we deem it necessary because it would add even more complexity to the `dispatch` workflow.

### Removing PR create API call from `copy-workflow`

To accomplish this I remove the use of `peter-evans/create-pull-request` completely and replace it with:
```
git checkout -B web3-bot/sync
git push origin web3-bot/sync -f
```

These 2 commands ensure that our local state, after copying all the necessary files, is reflected in the remote `web3-bot/sync` branch. They are only executed if needed.

### Dispatching `copy-workflow` and waiting for the completion

Unfortunately, `benc-uk/workflow-dispatch` is not capable of waiting for the dispatched workflow completion. It can also be replaced by a simple `gh workflow run` call(`gh` is already installed on the runners) so I decided to do just that.

Sadly, the latter doesn't know how to wait for the workflow completion either. Nor does it return the dispatched workflow `id` so we have to be clever about acquiring it. I decided to:
1. record a timestamp before dispatching `copy-workflow`;
1. dispatch `copy-workflow`;
1. request the latest run of the `copy-workflow` until it's start date is after the recorded timestamp;
1. record the id of that run of the `copy-workflow`.

This works because `copy-workflow`s are being dispatched sequentially which means there is never more than one `copy-workflow` running at a time.

Once we have the id in hand, we can use `gh run watch` to wait for the run to complete.

### Finding all the repositories that need PRs created

Once again, the Actions framework doesn't make it easy to retrieve this information. It doesn't support job outputs from matrix jobs(or rather it does but it only persist the output of the latest job which is not useful here).

The workaround I came up with is to:
- inside `copy-workflow`: conditionally execute the branch push step;
- inside `dispatch`:
    1. find all the matrix jobs executed by the `copy-workflow` run;
    1. filter them by the status of the branch push step execution;
    1. map the remaining jobs to the job names which are in `{owner}/{repository}` format.

### Creating the PRs

It can be achieved with `gh api -X POST "/repos/$job_name/pulls"`.

I also added a 3 second sleep after the GH API call. I decided to choose 3 seconds because that value comes up in multiple places across GH API so there's a chance it's going to work here too.

## Overhead

I ran `dispatch` workflow in my account to measure the overhead of this setup. To achieve this I:
- replaced the GH API call to create a PR in `dispatch` with an echo,
- removed everything but the push step from `copy-workflow`,
- replaced the push step in `copy-workflow` with an echo,
- made the push step to always execute.

This means that the overhead numbers are for a case where we have to create PRs(and sleep for 3 seconds) for all the repositories in the configuration.

| Repositories | Repositories per batch | Max parallel factor | Time spent in `copy-workflow` | Time spent "creating PRs" | Total execution time |
| --- | --- | --- | --- | --- | --- |
| 176 | 100 | 10 | &nbsp;&nbsp;&nbsp;2m 53s<br/>+ 1m 51s<br/>= 4m 44s<br/> | &nbsp;&nbsp;&nbsp;5m 27s<br/>+ 4m 7s<br/>= 9m 34s | 15m 15s |

## Testing

- [x] measured overhead of the process: [dispatch](https://github.com/galargh/.github/actions/runs/1608507431) + [copy-workflow(batch 0)](https://github.com/galargh/.github/actions/runs/1608508926) + [copy-workflow(batch 1)](https://github.com/galargh/.github/actions/runs/1608537400)
- [x] deployed new workflow to `.github-test-target`: [dispatch](https://github.com/protocol/.github/actions/runs/1611673020) + [copy-workflow](https://github.com/protocol/.github/actions/runs/1611674889) + [PR](https://github.com/protocol/.github-test-target/pull/35)
