### PR TITLE
add a workflow that adds a label to content matching query

### DIFF
--- a/.github/workflows/add-label-by-query.yml
+++ b/.github/workflows/add-label-by-query.yml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
     steps:
       - id: content
-        uses: protocol/github-api-action-library/find-content-by-query@beb79c79362921a1c90e3a2d3bce5a134b6b80c6
+        uses: protocol/github-api-action-library/find-content-by-query@v1
         with:
           query: ${{ github.event.inputs.query }}
       - run: |

--- a/.github/workflows/add-label-by-query.yml
+++ b/.github/workflows/add-label-by-query.yml
@@ -1,0 +1,38 @@
+name: Add Label by Query
+
+on:
+  workflow_dispatch:
+    inputs:
+      query:
+        description: Query that finds issues or pull requests to which the label should be added
+        required: true
+      label:
+        description: Label that should be added to issues or pull requests matching the query (leave blank for dry run)
+        required: false
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
+    steps:
+      - id: content
+        uses: protocol/github-api-action-library/find-content-by-query@beb79c79362921a1c90e3a2d3bce5a134b6b80c6
+        with:
+          query: ${{ github.event.inputs.query }}
+      - run: |
+          while read item; do
+            number="$(jq -r '.number' <<< "$item")"
+            nameWithOwner="$(jq -r '.repository.nameWithOwner' <<< "$item")"
+            if [ -z '${{ github.event.inputs.label }}' ]; then
+              echo "Would have added a label to $nameWithOwner#$number"
+            else
+              if gh issue edit "$number" --repo="$nameWithOwner" --add-label='${{ github.event.inputs.label }}'; then
+                echo "Successfully added label ${{ github.event.inputs.label }} to $nameWithOwner#$number"
+              else
+                echo "Failed to add label ${{ github.event.inputs.label }} to $nameWithOwner#$number"
+                echo "::warning ::$nameWithOwner#$number"
+              fi
+            fi
+          done <<< "$(jq -c '.[]' <<< '${{ steps.content.outputs.issues-or-pull-requests }}')"
+        shell: bash


### PR DESCRIPTION
Resolves https://github.com/protocol/.github/issues/40

###### Description

This PR adds a workflow that accepts a [issue or pull reuqest query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) and a label and adds that label to all the issue or pull requests matching the query.

If label is left blank, the workflow will just print the repository name with the owner and the number of the issue or pull request it would have added a label to.

*NOTE*: It will only be able to add labels to issues/PRs in repositories `web3-bot` was invited to. 

###### Testing
- [x] https://github.com/galargh/.github/actions/runs/1681726803 added `wontfix` to https://github.com/protocol/w3dt-stewards/issues/4 and https://github.com/protocol/w3dt-stewards/issues/3 based on the following query `is:issue is:closed repo:protocol/w3dt-stewards test`