### PR TITLE
upgrade lewagon/wait-on-check-action to v1.1.1

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.event.pull_request.user.login == 'web3-bot' && needs.automerge-check.outputs.status == 'true'
     steps:
     - name: Wait on tests
-      uses: lewagon/wait-on-check-action@bafe56a6863672c681c3cf671f5e10b20abf2eaa # v0.2
+      uses: lewagon/wait-on-check-action@752bfae19aef55dab12a00bc36d48acc46b77e9d # v1.1.1
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`v0.2.0` only accepts checks that conclude with `success`.
`v1.1.1` also accepts checks that conclude with `skipped`.

This is required for the JS workflow to be automergable because they execute some jobs conditionally (e.g. `release`). Until the next unified CI release, PRs from web3-bot in JS repos will have to be merged manually:
- https://github.com/libp2p/js-libp2p-tcp/pull/160
- https://github.com/libp2p/js-libp2p-interfaces/pull/145
- https://github.com/libp2p/js-libp2p-crypto/pull/235
- https://github.com/ipfs/js-blockstore-core/pull/15