### PR TITLE
restore npm run test:firefox-webworker

### DIFF
--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+      - run: npm run --if-present test:firefox-webworker
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           directory: ./.nyc_output


### PR DESCRIPTION
I think we removed this line by accident when modifying the script. 