### PR TITLE
simplify Go version upgrade procedure

### DIFF
--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -4,23 +4,28 @@ description: Copy workflow steps specific to go
 runs:
   using: "composite"
   steps:
+    # GitHub Actions Expressions do not support last item access/array length retrieval
+    - id: go
+      run: echo "::set-output name=version::$(jq -r '.[-1]' <<< '${{ toJSON(matrix.cfg.go.versions) }}')"
+      shell: bash
     - uses: actions/setup-go@v3
       with:
         # This should be the same Go version we use in the go-check workflow.
         # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
-        go-version: "1.19.x"
+        go-version: ${{ steps.go.outputs.version }}
     - name: bump go.mod go version if needed
       uses: protocol/multiple-go-modules@v1.2
       with:
         working-directory: ${{ env.TARGET_REPO_DIR }}
         run: |
           # We want our modules to support two Go versions at a time.
-          # As of August 2022, Go 1.19 is the latest stable.
           # go.mod's Go version declares the language version being used.
           # As such, it has to be the minimum of all Go versions supported.
-          # Bump this every six months, as new Go versions come out.
-          TARGET_VERSION=1.18
-          PREVIOUS_TARGET_VERSION=1.17
+          TARGET_VERSION='${{ matrix.cfg.go.versions[0] }}'
+          TARGET_VERSION="${TARGET_VERSION%.x}"
+          TARGET_MAJOR_VERSION="${TARGET_VERSION%.[0-9]*}"
+          TARGET_MINOR_VERSION="${TARGET_VERSION#[0-9]*.}"
+          PREVIOUS_TARGET_VERSION="$TARGET_MAJOR_VERSION.$(($TARGET_MINOR_VERSION-1))"
 
           # Note that the "<" comparison doesn't understand semver,
           # but it should be good enough for the foreseeable future.

--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -25,6 +25,10 @@ runs:
           TARGET_VERSION="${TARGET_VERSION%.x}"
           TARGET_MAJOR_VERSION="${TARGET_VERSION%.[0-9]*}"
           TARGET_MINOR_VERSION="${TARGET_VERSION#[0-9]*.}"
+          # Assumptions:
+          # - all versions are targetted incrementally
+          # - no versions are skipped
+          # - patch version is never pinned explicitly 
           PREVIOUS_TARGET_VERSION="$TARGET_MAJOR_VERSION.$(($TARGET_MINOR_VERSION-1))"
 
           # Note that the "<" comparison doesn't understand semver,

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,7 +3,12 @@
 # See https://github.com/protocol/.github/issues/254 for details.
 
 name: Release Checker
-on: [ workflow_call ]
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
 
 jobs:
   releaser:
@@ -14,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.x"
+          go-version: ${{ inputs.go-version }}
       - id: version
         name: Determine version
         if: hashFiles('version.json')

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,7 @@ on:
       go-version:
         required: true
         type: string
+        default: 1.19.x # TODO: remove once release-check is upgraded in all the targets
 
 jobs:
   releaser:

--- a/configs/README.md
+++ b/configs/README.md
@@ -41,4 +41,9 @@ You can use [testing](https://github.com/protocol/.github/tree/testing) branch f
 
 ## Upgrading Go
 
-To upgrade Go, modify the `defaults.go.versions` array in the [Go config](go.json). Keep the array sorted in an increasing order.
+To upgrade Go, modify the `defaults.go.versions` array in the [Go config](go.json).
+
+Remember to:
+- Keep the array sorted in increasing order,
+- Upgrade versions incrementally. Do not skip a version,
+- never pin the patch version (`"1.19.x"` is correct, `"1.19.8"` is incorrect).

--- a/configs/README.md
+++ b/configs/README.md
@@ -38,3 +38,7 @@ To customise the copy workflow further, you can add more fields to the `defaults
 ## Testing
 
 You can use [testing](https://github.com/protocol/.github/tree/testing) branch for worklow/configuration testing. Once you push your changes to the branch, a [dispatch](../.github/workflows/dispatch.yml) workflow will be triggered. The workflow will use [testing.json](testing.json) configuration file only. You can manipalate that configuration file as needed(you can copy all the `defaults` from [go.json](go.json) for [example](https://github.com/protocol/.github/commit/43476995428996a90ca95bf838f084ba1a710c68)).
+
+## Upgrading Go
+
+To upgrade Go, modify the `defaults.go.versions` array in the [Go config](go.json). Keep the array sorted in an increasing order.

--- a/configs/go.json
+++ b/configs/go.json
@@ -9,7 +9,10 @@
       ".github/workflows/tagpush.yml"
     ],
     "deploy_versioning": true,
-    "deploy_go": true
+    "deploy_go": true,
+    "go": {
+      "versions": [ "1.18.x", "1.19.x" ]
+    }
   },
   "repositories": [
     {

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -13,7 +13,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.x"
+          go-version: ${{{ config.go.versions[-1] }}}
       - name: Run repo-specific setup
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.18.x", "1.19.x" ]
+        go: ${{{ config.go.versions }}}
     env:
       COVERAGES: ""
       SKIP32BIT: false

--- a/templates/.github/workflows/release-check.yml
+++ b/templates/.github/workflows/release-check.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   release-check:
     uses: protocol/.github/.github/workflows/release-check.yml@master
+    with:
+      go-version: ${{{ config.go.versions[-1] }}}


### PR DESCRIPTION
Resolves #111

###### Description

This PR simplifies how Go versions are defined by making https://github.com/protocol/.github/blob/3104214787d953097a1d849fff039298e489f8a0/configs/go.json#L13-L15 the only place which explicitly states the version strings. All other places in which we referred to Go versions will transitively read from this config from now on.

It also describes all the steps that are required to bump Go version - i.e. update the version strings in the list. 


###### Testing

- [x] https://github.com/protocol/.github-test-target/pull/39
