### PR TITLE
always add a version.json file if it doesn't exist

### DIFF
--- a/.github/actions/copy-workflow-versioning/action.yml
+++ b/.github/actions/copy-workflow-versioning/action.yml
@@ -11,8 +11,6 @@ runs:
       run: |
         git fetch origin --unshallow # we need the entire commit history
         version=$(git describe --tags --abbrev=0 || true) # highest released version on current branch
-        if [[ -n "$version" ]]; then # only deply version.json if there's at least one release
-          printf '{"version": "%s"}' "$version" | jq . > version.json
-          git add version.json
-          git commit -m "add version.json file"
-        fi
+        printf '{"version": "%s"}' "$version" | jq . > version.json
+        git add version.json
+        git commit -m "add version.json file"


### PR DESCRIPTION
Resolves #264

It will add a `version.json` file with the following content in repos that don't have releases yet:
```
{
  "version": ""
}
```

Do you think we should target `next` or `master` with this? If we target `master`, it will create new PRs but only in repos without `version.json` which shouldn't be too bad.