### PR TITLE
allow specifying go vet flags

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     name: All
     env:
-      RUNGOGENERATE: false
+      CONFIG: '{}'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,11 +18,8 @@ jobs:
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''
       - name: Read config
-        if: hashFiles('./.github/workflows/go-check-config.json') != ''
-        run: |
-          if jq -re .gogenerate ./.github/workflows/go-check-config.json; then
-            echo "RUNGOGENERATE=true" >> $GITHUB_ENV
-          fi
+        if: hashFiles('.github/workflows/go-check-config.json') != ''
+        run: echo "CONFIG=$(jq -c '.' .github/workflows/go-check-config.json)" >> $GITHUB_ENV
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@c8caa92bad8c27ae734c6725b8a04932d54a147b # 2021.1.2 (v0.2.2)
       - name: Check that go.mod is tidy
@@ -47,7 +44,7 @@ jobs:
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         uses: protocol/multiple-go-modules@v1.2
         with:
-          run: go vet $GOVETFLAGS ./...
+          run: go vet ${{ fromJSON(env.CONFIG).govet.flags }} ./...
       - name: staticcheck
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         uses: protocol/multiple-go-modules@v1.2
@@ -57,7 +54,7 @@ jobs:
             staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
       - name: go generate
         uses: protocol/multiple-go-modules@v1.2
-        if: (success() || failure()) && env.RUNGOGENERATE == 'true'
+        if: (success() || failure()) && fromJSON(env.CONFIG).gogenerate == true
         with:
           run: |
             git clean -fd # make sure there aren't untracked files / directories

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         uses: protocol/multiple-go-modules@v1.2
         with:
-          run: go vet ./...
+          run: go vet $GOVETFLAGS ./...
       - name: staticcheck
         if: ${{ success() || failure() }} # run this step even if the previous one failed
         uses: protocol/multiple-go-modules@v1.2
@@ -68,4 +68,3 @@ jobs:
               git status --short
               exit 1
             fi
-


### PR DESCRIPTION
This PR will make it possible to provide flags for `go vet` command via `go-check-config.json` object.

###### Why?

One of the reasons why https://github.com/ipld/go-ipld-prime-proto/pull/24 cannot be merged is because `go vet` fails with `composite literal uses unkeyed fields` (see https://github.com/ipld/go-ipld-prime-proto/runs/4483048466?check_suite_focus=true). Unfortunately, the solution of changing the code to avoid this error doesn't work here because `ipldsch_satisfaction.go` is an autogenerated file. That's why I think allowing to provide `-composites=false` to `go vet` would be desirable in this case.

I also tried to see if there is a way to add some magic comment to ignore this file during `go vet` but it seems it does not exist - https://github.com/golang/go/issues/18432#issuecomment-269235329

`go-check-config.json` example:
```
{
  "govet": { 
    "flags": "-composites=false"
  }
}
```

###### Testing

- [x] successfully ran `go generate` with `{"gogenerate":true}` config (`go vet` correctly failed) - https://github.com/galargh/go-ipld-prime-proto/actions/runs/1707665427
- [x] successfully ran `go vet` with `{"govet":{"flags":"-composites=false"}}` config - https://github.com/galargh/go-ipld-prime-proto/actions/runs/1707657893

 

