### PR TITLE
check if tag already exists in release-check

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,7 +9,7 @@ jobs:
   releaser:
     runs-on: ubuntu-latest
     env:
-      INITIAL_RUN: "false"
+      TAG_EXISTS: "true"
       VERSION: "" # the version number read from version.json
       COMPARETO: "" # the version number to compare this version to
       GORELEASE: ""
@@ -22,29 +22,27 @@ jobs:
         with:
           go-version: "1.17.x"
       - name: Determine version
+        if: hashFiles('version.json')
         run: echo "VERSION=$(jq -r .version version.json)" >> $GITHUB_ENV
-      - name: Check if this is the initial deployment
-        # This is the initial run (deploying the version.json to this repo) if
-        # 1. version.json didn't exist before, AND
-        # 2. there doesn't exist a git tag for the version (as read from version.json)
-        # In that case, we don't need to run the rest of the workflow.
+      - name: Check if the tag already exists
+        # Check if a git tag for the version (as read from version.json) exists
+        # If that is the case, we don't need to run the rest of the workflow.
+        if: env.VERSION != ''
         run: |
-          git fetch origin ${{ github.event.pull_request.base.sha }}
           git fetch origin --tags
-          read -ra arr <<< $(git diff-index ${{ github.event.pull_request.base.sha }} -- version.json)
           status=0
           git rev-list $VERSION &> /dev/null || status=$?
-          if [[ "${arr[4]}" == "A" && $status == 0 ]]; then
-            echo "INITIAL_RUN=true" >> $GITHUB_ENV
+          if [[ $status != 0 ]]; then
+            echo "TAG_EXISTS=false" >> $GITHUB_ENV
           fi
       - name: Install semver (node command line tool)
-        if: env.INITIAL_RUN == 'false'
+        if: env.TAG_EXISTS == 'false'
         run: npm install -g "https://github.com/npm/node-semver#e79ac3a450e8bb504e78b8159e3efc7089569" # v7.3.5
       - name: Check version
-        if: env.INITIAL_RUN == 'false'
+        if: env.TAG_EXISTS == 'false'
         run: semver ${{ env.VERSION }} # fails if the version is not a valid semver version (e.g. v0.1 would fail)
       - name: Determine version number to compare to
-        if: env.INITIAL_RUN == 'false'
+        if: env.TAG_EXISTS == 'false'
         # We need to determine the version number we want to compare to,
         # taking into account that this might be a (patch) release on a release branch.
         # Example:
@@ -62,7 +60,7 @@ jobs:
           fi
           echo "COMPARETO=$v" >> $GITHUB_ENV
       - name: Post output
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO == ''
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO == ''
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
         with:
           header: release-check
@@ -72,7 +70,7 @@ jobs:
 
             This is the first release of this module.
       - name: run git diff on go.mod file(s)
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
         run: |
           # First get the diff for the go.mod file in the root directory...
           output=$(git diff ${{ env.COMPARETO }}..HEAD -- './go.mod')
@@ -84,14 +82,14 @@ jobs:
           fi
           printf "GOMODDIFF<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
       - name: Run gorelease
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
         # see https://github.com/golang/exp/commits/master/cmd/gorelease
         run: |
           go install golang.org/x/exp/cmd/gorelease@b4e88ed8e8aab63a9aa9a52276782ebbc547adef
           output=$((gorelease -base ${{ env.COMPARETO }}) 2>&1 || true)
           printf "GORELEASE<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
       - name: Check Compatibility
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
         run: |
           go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
           output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARETO }}..HEAD" ./... || true)
@@ -129,10 +127,10 @@ jobs:
           ```
           ${{ env.RELEASE_BRANCH_NOTE }}
           EOF' >> $GITHUB_ENV
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != ''
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
       - name: Post message on PR
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name == github.repository
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: release-check
           recreate: true
@@ -143,4 +141,4 @@ jobs:
           message="${message//$'\n'/'%0A'}"
           message="${message//$'\r'/'%0D'}"
           echo "::notice ::$message"
-        if: env.INITIAL_RUN == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository
+        if: env.TAG_EXISTS == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Resolves https://github.com/protocol/.github/issues/285

In this PR I propose to replace `INITIAL_RUN` check with `TAG_EXISTS` check in `release-check` workflow.

In the new setup, we will run the rest of the `release-check` workflow only if a git tag for `version` from `version.json` does NOT exist yet. 

In particular, if the `version` is an empty string, we will not execute the rest of the workflow.