### PR TITLE
allow specifying custom PATH for 386 arch

### DIFF
--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -47,7 +47,9 @@ jobs:
         env:
           GOARCH: 386
         with:
-          run: go test -v ./...
+          run: |
+            export "PATH=${{ env.PATH_386 }}:$PATH"
+            go test -v ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
This will enable merging unified CI in `go-openssl` repo (see https://github.com/libp2p/go-openssl/pull/20). We need to be able to specify a custom PATH for 32bit windows build because it requires `/c/msys64/mingw32/bin` to be available. We cannot set it globally because 64bit windows builds need `/c/msys64/mingw32/bin` instead. As an alternative approach I tried setting `CC_FOR_windows_386` but the compiler calls other underlying tools (like `ld` for example) by name, I think, so if they're not on PATH, they cannot be found.

###### Testing
- [x] PR Builder https://github.com/libp2p/go-openssl/pull/20