### PR TITLE
chore: add go-pinning-service-http-client

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -85,6 +85,7 @@
     { "target": "ipfs/go-namesys" },
     { "target": "ipfs/go-path" },
     { "target": "ipfs/go-peertaskqueue" },
+    { "target": "ipfs/go-pinning-service-http-client" },
     { "target": "ipfs/go-qringbuf" },
     { "target": "ipfs/go-todocounter" },
     { "target": "ipfs/go-unixfs" },


### PR DESCRIPTION
I'd like to fix https://github.com/ipfs/go-pinning-service-http-client/issues/14 and make release using unified CI.

First step is to add https://github.com/ipfs/go-pinning-service-http-client  here