### PR TITLE
fix: update pull request target to use wildcard

### DIFF
--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -5,7 +5,7 @@ on:
       - $default-branch # with #262 - ${{{ github.default_branch }}}
   pull_request:
     branches:
-      - $default-branch # with #262 - ${{{ github.default_branch }}}
+      - **
 
 jobs:
 

--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - $default-branch # with #262 - ${{{ github.default_branch }}}
   pull_request:
-    branches:
-      - **
 
 jobs:
 


### PR DESCRIPTION
If `branches` is set to the default branch, it means CI will only run on a PR that targets the default branch.

Sometimes we have release branches like `/release/v1.0.0` which use use to backport fixes to previous versions - we still want CI to run on these backport PRs so change the PR branch target to run CI on PRs that target any branch.