### PR TITLE
Extract PR creation out of Dispatch workflow

### DIFF
--- a/.github/workflows/create-prs.yml
+++ b/.github/workflows/create-prs.yml
@@ -24,15 +24,7 @@ jobs:
         run: |
           targets=()
           for config in configs/*.json; do
-            if [[ $GITHUB_REF == refs/heads/testing && $config != configs/testing.json ]]; then
-              continue
-            fi
-            if [[ $GITHUB_REF != refs/heads/testing && $config == configs/testing.json ]]; then
-              continue
-            fi
-            echo "::group::$config"
             targets+=($(jq -rc ".repositories[] | .target" $config))
-            echo "::endgroup::"
           done
           failed=()
           for target in ${targets[@]}; do

--- a/.github/workflows/create-prs.yml
+++ b/.github/workflows/create-prs.yml
@@ -11,6 +11,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: 'master'
       - name: Sync PRs in targets that need it
         env:
           PR_TITLE: 'sync: update CI config files'
@@ -18,43 +20,47 @@ jobs:
         run: |
           targets=()
           for config in configs/*.json; do
-            echo "::group::$config"
             if [[ $GITHUB_REF == refs/heads/testing && $config != configs/testing.json ]]; then
               continue
             fi
             if [[ $GITHUB_REF != refs/heads/testing && $config == configs/testing.json ]]; then
               continue
             fi
+            echo "::group::$config"
             targets+=($(jq -rc ".repositories[] | .target" $config))
             echo "::endgroup::"
           done
           failed=()
-          for target in $targets; do
+          for target in ${targets[@]}; do
             echo "Processing ${target}"
             base="$(gh api "/repos/${target}" --jq '.default_branch')"
             # checks if a PR needs to be created
-            if gh api -X GET "/repos/${target}/branches/${{ env.PR_BRANCH }}"; then
-              if gh api -X GET "/repos/${target}/pulls" -f head="$(echo "${target}" | cut -d/ -f1):${{ env.PR_BRANCH }}" -f base="$base"; then
+            if [[ "$(gh api -X GET "/repos/${target}/compare/${base}...${{ env.PR_BRANCH }}" --jq '.status')" == 'ahead' ]]; then
+              if [[ "$(gh api -X GET "/repos/${target}/pulls" -f head="$(echo "${target}" | cut -d/ -f1):${{ env.PR_BRANCH }}" -f base="$base" --jq 'length')" != '0' ]] ; then
                 echo "The PR already exists. Skipping."
                 continue
               fi
             else
-              echo "The branch does not exist. Skipping."
+              echo "The branch does not exist or has diverged from ${base}. Skipping."
               continue
             fi
             # tries to create a PR in target
-            pr_create_attempt_interval_in_seconds=3
             pr_create_attempt=1
-            pr_create_max_attempts=6
+            pr_create_max_attempts=12
+            pr_create_attempt_interval_in_seconds=1
+            pr_create_cooldown_in_seconds=1
+            # max cumulative sleep time - 68.25 minutes
             while true; do
               if result="$(gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f head="${{ env.PR_BRANCH }}" -f base="$base")"; then
                 echo "Successfully created a PR for '$target' ($pr_create_attempt/$pr_create_max_attempts)"
+                echo "Sleeping for $pr_create_cooldown_in_seconds seconds before creating a next one"
+                sleep $pr_create_cooldown_in_seconds
                 break
               fi
-              if [[ "$(jq -r '.errors[0].message' <<< "$result")" == 'You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.' ]]; then
+              if [[ "$(jq -r '.message' <<< "$result")" == 'You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.' ]]; then
                 if (( pr_create_attempt < pr_create_max_attempts )); then
                   echo "Failed to create a PR for '$target' due to secondary rate limit ($pr_create_attempt/$pr_create_max_attempts)"
-                  echo "Sleeping for $pr_create_attempt_interval_in_seconds before trying again"
+                  echo "Sleeping for $pr_create_attempt_interval_in_seconds seconds before trying again"
                   sleep $pr_create_attempt_interval_in_seconds
                   pr_create_attempt_interval_in_seconds=$((pr_create_attempt_interval_in_seconds * 2))
                   pr_create_attempt=$((pr_create_attempt + 1))

--- a/.github/workflows/create-prs.yml
+++ b/.github/workflows/create-prs.yml
@@ -1,7 +1,11 @@
 name: Create PRs
 
 on:
-  [ workflow_dispatch ]
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Dispatch]
+    types:
+      - completed
 
 jobs:
   dispatch:
@@ -12,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: 'master'
+          ref: ${{ github.event.workflow_run.head_commit.id || github.sha }}
       - name: Sync PRs in targets that need it
         env:
           PR_TITLE: 'sync: update CI config files'

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           targets=()
           for config in configs/*.json; do
-            echo "::group::$config"
             if [[ $GITHUB_REF == refs/heads/testing && $config != configs/testing.json ]]; then
               continue
             fi
             if [[ $GITHUB_REF != refs/heads/testing && $config == configs/testing.json ]]; then
               continue
             fi
+            echo "::group::$config"
             defaults=$(jq -c '.defaults' $config)
             # values defined in the repository object will override the default values
             # e.g. { "files": ["a", "b"] } + { "files": ["c"] } = { "files": ["c"] }
@@ -104,43 +104,3 @@ jobs:
           # checks every 3 seconds until the copy workflow run's status is completed
           # redirects the stdout to /dev/null because it is very chatty
           gh run watch "${{ steps.run.outputs.id }}" --repo "${{ env.WORKFLOW_REPO }}" > /dev/null
-      - id: jobs
-        name: Find copy workflow jobs that pushed changes
-        env:
-          STEP_NAME: 'Force push web3-bot/sync branch'
-        run: |
-          targets="$(gh api --paginate '/repos/${{ env.WORKFLOW_REPO }}/actions/runs/${{ steps.run.outputs.id }}/jobs' | jq '.jobs | map(select(.steps[] | select(.name == "${{ env.STEP_NAME }}") and select(.conclusion == "success"))) | map(.name)' | jq -sc 'add')"
-          echo "::set-output name=targets::$targets"
-      - name: Sync PRs in targets that need it
-        env:
-          PR_TITLE: 'sync: update CI config files'
-          PR_BODY: 'Syncing to commit ${{ github.event.head_commit.url }}.'
-          PR_BRANCH: 'web3-bot/sync'
-        run: |
-          failed=()
-          for target in $(jq -r '.[]' <<< ${{ toJson(steps.jobs.outputs.targets) }}); do
-            base="$(gh api "/repos/${target}" --jq '.default_branch')"
-            # tries to create a PR in target
-            if result="$(gh api "/repos/$target/pulls" -f title="${{ env.PR_TITLE }}" -f body="${{ env.PR_BODY }}" -f head="${{ env.PR_BRANCH }}" -f base="$base")"; then
-              echo "Successfully created a PR for '$target'"
-            elif [[ "$(jq -r '.errors[0].message' <<< "$result")" == 'A pull request already exists'* ]]; then
-              number="$(gh api "/repos/$target/pulls?head=${{ env.PR_BRANCH }}&per_page=1&state=open" --jq '.[0].number')"
-              # tries to update the PR in target
-              if result="$(gh api -X PATCH "/repos/$target/pulls/$number" -f body="${{ env.PR_BODY }}" -f base="$base")"; then
-                echo "Successfully updated the PR for '$target'"
-              else
-                echo "$result"
-                echo "Failed to update the PR for '$target'"
-                failed+=("$target(update)")
-              fi
-            else
-              echo "$result"
-              echo "Failed to create a PR for '$target'"
-              failed+=("$target(create)")
-            fi
-            sleep 3
-          done
-          if ((${#failed[@]})); then
-            echo "::error ::Failed to sync PRs in: ${failed[@]}"
-            exit 1
-          fi


### PR DESCRIPTION
In this PR I remove PR creation phase out of Dispatch workflow entirely. Instead, I add a new trigger to the Create PRs workflow - `workflow_run`. With this Create PRs is triggered whenever Dispatch workflow finishes.

I also fix Create PRs workflow. Here's how it works after the changes:
1. Checkout `.github` at the same ref Dispatch workflow was using or at the branch that was chosen when dispatching the run manually.
1. Collect all the repositories from JSON configs. 
1. For each repository:
    1. Check if `web3-bot/sync` branch exists and if it is `ahead` of the default branch. If not, skip processing this repository.
    1. Check if an open PR from `web3-bot/sync` to the default branch exists. If not, skip processing this repository.
    1. Try:
        1. Create PR from `web3-bot/sync` to the default branch. 
        1. If successful, sleep for 1 second and stop trying.
        1. If failed with secondary rate limit error message and tried less than 12 times, sleep for INTERVAL (starts at 1) seconds, double the interval and try again.
        1. If failed with other reason or exceeded try attempt limit, warn about failing to create a PR for this repository.
        
The `Try` loop in the Create PRs workflow can take up to 70 minutes. It is not documented anywhere but from experience, I have seen us being locked out of PR creation for 30 minutes.

###### Testing

I have used Create PRs workflow during 2022-04-04 release.