### PR TITLE
Clean up configs/go.json after 2022-04-04 release

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -14,7 +14,6 @@
   "repositories": [
     { "target": "filecoin-project/go-amt-ipld" },
     { "target": "filecoin-project/go-bitfield" },
-    { "target": "filecoin-project/go-commp-utils" },
     { "target": "filecoin-project/go-fil-commp-hashhash" },
     { "target": "filecoin-project/go-hamt-ipld" },
     { "target": "filecoin-project/go-indexer-core" },

--- a/configs/go.json
+++ b/configs/go.json
@@ -18,7 +18,7 @@
     { "target": "filecoin-project/go-hamt-ipld" },
     { "target": "filecoin-project/go-indexer-core" },
     { "target": "filecoin-project/go-legs" },
-    { "target": "filecoin-project/indexer-reference-provider" },
+    { "target": "filecoin-project/index-provider" },
     { "target": "filecoin-project/storetheindex" },
     { "target": "filecoin-shipyard/js-lotus-client-schema" },
     { "target": "ipfs-shipyard/dnslink-dnsimple" },


### PR DESCRIPTION
I've noticed a couple of issues with the config during the recent release. This PR fixes them. 

`filecoin-project/go-commp-utils` cannot use Unified CI because it has a submodule and, sadly, it's not supported by our Go workflows currently. See https://github.com/filecoin-project/go-commp-utils/tree/master/extern

`filecoin-project/indexer-reference-provider` changed name to `filecoin-project/index-provider`