### PR TITLE
allow optional ADDITIONAL_TEST_OPTIONS env var to ammend `go test` command

### DIFF
--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -40,7 +40,9 @@ jobs:
           # Use -coverpkg=./..., so that we include cross-package coverage.
           # If package ./A imports ./B, and ./A's tests also cover ./B,
           # this means ./B's coverage will be significantly higher than 0%.
-          run: go test -v -coverprofile=module-coverage.txt -coverpkg=./... ./...
+          run: |
+            additional_opts=( $ADDITIONAL_TEST_OPTIONS )
+            go test -v -coverprofile=module-coverage.txt -coverpkg=./... "${additional_opts[@]}" ./...
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
         uses: protocol/multiple-go-modules@v1.2
@@ -54,7 +56,9 @@ jobs:
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2
         with:
-          run: go test -v -race ./...
+          run: |
+            additional_opts=( $ADDITIONAL_TEST_OPTIONS )
+            go test -v -race ./... "${additional_opts[@]}"
       - name: Collect coverage files
         shell: bash
         run: echo "COVERAGES=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_ENV


### PR DESCRIPTION
Ref: https://github.com/ipld/go-ipld-prime/pull/409

or ... got a better idea or a more elegant way to achieve this kind of thing?

1. I can't use `-coverpkg` and run vanilla tests (https://github.com/golang/go/issues/23410, https://github.com/ipld/go-ipld-prime/blob/master/schema/gen/go/HACKME_testing.md)
2. I can turn off plugins to make it work but it skips some important tests in the process and it needs a build tag to be passed in `go test`, hence this change
3. I can add those tests back in with an additional custom workflow
4. I don't really care that much about coverage at the moment, highest priority is to get proper CI running, another way forward here might be an option to just turn off coverage entirely
