### PR TITLE
fix: remove codecov directory

### DIFF
--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -37,7 +37,6 @@ jobs:
       - run: npm run --if-present test:node
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: node
 
   test-chrome:
@@ -52,7 +51,6 @@ jobs:
       - run: npm run --if-present test:chrome
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: chrome
 
   test-chrome-webworker:
@@ -67,7 +65,6 @@ jobs:
       - run: npm run --if-present test:chrome-webworker
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: chrome-webworker
 
   test-firefox:
@@ -82,7 +79,6 @@ jobs:
       - run: npm run --if-present test:firefox
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: firefox
 
   test-firefox-webworker:
@@ -97,7 +93,6 @@ jobs:
       - run: npm run --if-present test:firefox-webworker
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: firefox-webworker
 
   test-electron-main:
@@ -112,7 +107,6 @@ jobs:
       - run: npx xvfb-maybe npm run --if-present test:electron-main
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: electron-main
 
   test-electron-renderer:
@@ -127,7 +121,6 @@ jobs:
       - run: npx xvfb-maybe npm run --if-present test:electron-renderer
       - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
         with:
-          directory: ./.nyc_output
           flags: electron-renderer
 
   release:


### PR DESCRIPTION
The new aegir release writes the coverage report into the default location so it will be found by codecov-action automagically - no need to specify a path as an arg, which doesn't work with monorepos anyway.