### PR TITLE
feat: use shuffle during go-tests (fixes #237)

### DIFF
--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -40,7 +40,7 @@ jobs:
           # Use -coverpkg=./..., so that we include cross-package coverage.
           # If package ./A imports ./B, and ./A's tests also cover ./B,
           # this means ./B's coverage will be significantly higher than 0%.
-          run: go test -v -coverprofile=module-coverage.txt -coverpkg=./... ./...
+          run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
         uses: protocol/multiple-go-modules@v1.2
@@ -49,7 +49,7 @@ jobs:
         with:
           run: |
             export "PATH=${{ env.PATH_386 }}:$PATH"
-            go test -v ./...
+            go test -v -shuffle=on ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
Fixes https://github.com/protocol/.github/issues/237

We dropped support for go 1.16, which means we can use `-shuffle` during go tests now.