### PR TITLE
fix: dependency resolution problem in Go version upgrades

### DIFF
--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -20,6 +20,7 @@ runs:
           # As such, it has to be the minimum of all Go versions supported.
           # Bump this every six months, as new Go versions come out.
           TARGET_VERSION=1.17
+          PREVIOUS_TARGET_VERSION=1.16
 
           # Note that the "<" comparison doesn't understand semver,
           # but it should be good enough for the foreseeable future.
@@ -29,9 +30,9 @@ runs:
             echo "GO_VERSION_BUMP=1" >> $GITHUB_ENV
 
             # We tidy immediately because some updates require it
-            # We ensure dependencies are resolved to versions supported by CURRENT_VERSION of Go
+            # We ensure dependencies are resolved to versions supported by the PREVIOUS_TARGET_VERSION of Go
             # It also modifies Go version in the go.mod which ensures there's a diff
-            go mod tidy -go=$CURRENT_VERSION && go mod tidy -go=$TARGET_VERSION
+            go mod tidy -go=$PREVIOUS_TARGET_VERSION && go mod tidy -go=$TARGET_VERSION
 
             $ Just in case, check again if everything's OK after the version upgrade
             go mod tidy

--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -28,10 +28,12 @@ runs:
           if [[ $CURRENT_VERSION < $TARGET_VERSION ]]; then
             echo "GO_VERSION_BUMP=1" >> $GITHUB_ENV
 
-            # Update the version in go.mod. This alone ensures there's a diff.
-            go mod edit -go $TARGET_VERSION
-
             # We tidy immediately because some updates require it
+            # We ensure dependencies are resolved to versions supported by CURRENT_VERSION of Go
+            # It also modifies Go version in the go.mod which ensures there's a diff
+            go mod tidy -go=$CURRENT_VERSION && go mod tidy -go=$TARGET_VERSION
+
+            $ Just in case, check again if everything's OK after the version upgrade
             go mod tidy
 
             # In the future, "go fix" may make changes to Go code,


### PR DESCRIPTION
This PR ensures we take Go's advice on how to handle dependency resolution issues when we want previous Go versions to stay supported. See this for example:
```
  github.com/ipfs/go-graphsync/tools imports
  	github.com/hannahhoward/cbor-gen-for imports
  	github.com/urfave/cli/v2 imports
  	github.com/cpuguy83/go-md2man/v2/md2man loaded from github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d,
  	but go 1.16 would select v2.0.0
  github.com/ipfs/go-graphsync/allocator imports
  	github.com/ipfs/go-log/v2 imports
  	go.uber.org/zap tested by
  	go.uber.org/zap.test imports
  	go.uber.org/goleak loaded from go.uber.org/goleak@v1.1.11,
  	but go 1.16 would select v1.1.12
  github.com/ipfs/go-graphsync/allocator imports
  	github.com/ipfs/go-log/v2 imports
  	go.uber.org/zap tested by
  	go.uber.org/zap.test imports
  	go.uber.org/goleak imports
  	go.uber.org/goleak/internal/stack loaded from go.uber.org/goleak@v1.1.11,
  	but go 1.16 would select v1.1.12
  
  To upgrade to the versions selected by go 1.16:
  	go mod tidy -go=1.16 && go mod tidy -go=1.17
  If reproducibility with go 1.16 is not needed:
  	go mod tidy -compat=1.17
  For other options, see:
  	https://golang.org/doc/modules/prunin
```

And this in particular:
```
  To upgrade to the versions selected by go 1.16:
  	go mod tidy -go=1.16 && go mod tidy -go=1.17
```

`go mod tidy -go=1.17` updates Go version in the modfile - that's why we don't need a separate call to `go mod edit` the version.

We can target the master branch because this is going to affect only those repositories in which the version upgrade didn't work previously - `ipfs/go-graphsync` to be exact. 
