### PR TITLE
chore: upgrade staticcheck to 2022.1.3 (v0.3.3)

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -24,7 +24,7 @@ jobs:
             echo "RUNGOGENERATE=true" >> $GITHUB_ENV
           fi
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@d7e217c1ff411395475b2971c0824e1e7cc1af98 # 2022.1 (v0.3.0)
+        run: go install honnef.co/go/tools/cmd/staticcheck@376210a89477dedbe6fdc4484b233998650d7b3c # 2022.1.3 (v0.3.3)
       - name: Check that go.mod is tidy
         uses: protocol/multiple-go-modules@v1.2
         with:


### PR DESCRIPTION
Hopefully, this will be enough to upgrade to Go 1.19.

Required by: https://github.com/protocol/.github/issues/362