### PR TITLE
change supported Go versions from 1.17 and 1.18 to 1.18 and 1.19

### DIFF
--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -8,18 +8,18 @@ runs:
       with:
         # This should be the same Go version we use in the go-check workflow.
         # go mod tidy, go vet, staticcheck and gofmt might behave differently depending on the version.
-        go-version: "1.18.x"
+        go-version: "1.19.x"
     - name: bump go.mod go version if needed
       uses: protocol/multiple-go-modules@v1.2
       with:
         working-directory: ${{ env.TARGET_REPO_DIR }}
         run: |
           # We want our modules to support two Go versions at a time.
-          # As of March 2022, Go 1.18 is the latest stable.
+          # As of August 2022, Go 1.19 is the latest stable.
           # go.mod's Go version declares the language version being used.
           # As such, it has to be the minimum of all Go versions supported.
           # Bump this every six months, as new Go versions come out.
-          TARGET_VERSION=1.17
+          TARGET_VERSION=1.18
 
           # Note that the "<" comparison doesn't understand semver,
           # but it should be good enough for the foreseeable future.

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.18.x"
+          go-version: "1.19.x"
       - name: Determine version
         if: hashFiles('version.json')
         run: echo "VERSION=$(jq -r .version version.json)" >> $GITHUB_ENV

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -13,7 +13,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.18.x"
+          go-version: "1.19.x"
       - name: Run repo-specific setup
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.17.x", "1.18.x" ]
+        go: [ "1.18.x", "1.19.x" ]
     env:
       COVERAGES: ""
     runs-on: ${{ format('{0}-latest', matrix.os) }}


### PR DESCRIPTION
Required by: https://github.com/protocol/.github/issues/362

Adds support for Go 1.19 and drops Go 1.17.