### PR TITLE
feat: enable support for opting in to technical preview updates

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
+        ref: ${{ matrix.cfg.source_ref || github.ref }}
     - name: determine GitHub default branch
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: |

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -7,6 +7,7 @@ name: Dispatch
 on:
   push:
     branches: [ master, testing ]
+  workflow_dispatch:
 
 env:
   # Number of repositories in a batch.
@@ -23,6 +24,7 @@ env:
 
 jobs:
   matrix:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/testing'
     name: Batch targets
     runs-on: ubuntu-latest
     outputs:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ This check will be run in repositories that set `gogenerate` to `true` in `.gith
 Note that depending on the code generators used, it might be necessary to [install those first](#additional-setup-steps).
 The generators must also be deterministic, to prevent CI from getting different results each time.
 
+## Technical Preview
+
+You can opt-in to receive early updates from the `next` branch in-between official Unified CI releases.
+
+To do so you have to set `source_ref` property to `next` on your repository target object in the configuration file.
+```json
+{
+  "repositories": [
+    {
+      "target": "pl-strflt/example",
+      "source_ref": "next"
+    }
+  ]
+}
+```
+
+_Warning_: `next` branch updates are much more frequent than those from `master`.
+
 ## Technical Details
 
 This repository currently defines two workflows for Go repositories:


### PR DESCRIPTION
###### Description

This PR adds support for a new property `source_ref` in the repository targets. When `source_ref` is set, `Deploy` workflow will check out `protocol/.github` at said ref and copy the workflows from there instead of `github.ref` (the branch in which the workflow is running). 

If `source_ref` is not specified, `Deploy` workflow will act exactly as it did before i.e. it will check out `github.ref`.

###### Why now?

We'd like to let users opt-in to Go 1.19 upgrade before we're able to perform the official release (https://github.com/protocol/.github/issues/362).

But I think this will become useful beyond this immediate need, e.g. for continuous testing of the `next` branch. 

###### Testing
- [x] push to `testing` without setting `source_ref` on `protocol/.github-test-target ` - https://github.com/protocol/.github/runs/7674190338?check_suite_focus=true
```
Run actions/checkout@v2
  with:
    path: template-repo
    ref: refs/heads/testing
```
- [x] push to `testing` with `source_ref` set to `next` on `protocol/.github-test-target ` - https://github.com/protocol/.github/runs/7674236444?check_suite_focus=true
```
Run actions/checkout@v2
  with:
    path: template-repo
    ref: next
```