### PR TITLE
feat: add go-libp2p to preview

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -343,7 +343,8 @@
       "target": "libp2p/go-flow-metrics"
     },
     {
-      "target": "libp2p/go-libp2p"
+      "target": "libp2p/go-libp2p",
+      "source_ref": "preview"
     },
     {
       "target": "libp2p/go-libp2p-asn-util"


### PR DESCRIPTION
What I did:

1. create the branch `preview` from `next`: https://github.com/protocol/.github/tree/preview ([diff](https://github.com/protocol/.github/compare/next...preview))
2. update `source_ref` in `go-libp2p`

Merging into master will trigger a deployment of the `preview` version.

Taking into account the discussion in https://github.com/protocol/.github/issues/367 we use a branch that is not `next` until we agree on a definitive naming.