### PR TITLE
hide goimport fix commit behind git diff check

### DIFF
--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -59,6 +59,7 @@ runs:
               sed -i 's/ioutil.TempDir/os.MkdirTemp/' "${file}";
               sed -i 's/ioutil.TempFile/os.CreateTemp/' "${file}";
               sed -i 's/ioutil.WriteFile/os.WriteFile/' "${file}";
+              sed -i 's/ioutil.Discard/io.Discard/' "${file}";
             done <<< "$(find . -type f -name '*.go')"
 
             go install golang.org/x/tools/cmd/goimports@v0.1.12

--- a/.github/actions/copy-workflow-go/action.yml
+++ b/.github/actions/copy-workflow-go/action.yml
@@ -64,8 +64,10 @@ runs:
             go install golang.org/x/tools/cmd/goimports@v0.1.12
             goimports -w .
 
-            git add .
-            git commit -m "stop using the deprecated io/ioutil package"
+            if ! git diff-index --quiet; then
+              git add .
+              git commit -m "stop using the deprecated io/ioutil package"
+            fi
           fi
     - name: go mod tidy (on initial workflow deployment)
       if: ${{ env.INITIAL_WORKFLOW_DEPLOYMENT == 1 }}
@@ -84,7 +86,7 @@ runs:
       shell: bash
       run: |
         gofmt -s -w .
-        if ! git diff --quiet; then
+        if ! git diff-index --quiet; then
           git add .
           git commit -m "run gofmt -s"
         fi


### PR DESCRIPTION
`git commit` exists with `1` if it has nothing to commit - that's why we need to check if there's anything to commit ahead of time. 