### PR TITLE
remove go-libp2p from preview

### DIFF
--- a/.github/workflows/stale-repos.yml
+++ b/.github/workflows/stale-repos.yml
@@ -35,6 +35,7 @@ jobs:
 
           echo "::set-output name=repos::$repos"
       - name: find deleted / archived repositories
+        if: ${{ steps.repos.outputs.repos != '[]' }}
         run: |
           status=0
           while read config; do

--- a/configs/go.json
+++ b/configs/go.json
@@ -343,8 +343,7 @@
       "target": "libp2p/go-flow-metrics"
     },
     {
-      "target": "libp2p/go-libp2p",
-      "source_ref": "preview"
+      "target": "libp2p/go-libp2p"
     },
     {
       "target": "libp2p/go-libp2p-asn-util"


### PR DESCRIPTION
If I understand correctly, `preview` is currently behind `master`. We're currently running into build failures due to checkout action, the hope is that by upgrading to `checkout@v3`, these problems will go away.

Example run: https://github.com/libp2p/go-libp2p/actions/runs/3092737094/jobs/5004342667