### PR TITLE
do not exec stale repos check on empty config

### DIFF
--- a/.github/workflows/stale-repos.yml
+++ b/.github/workflows/stale-repos.yml
@@ -35,6 +35,7 @@ jobs:
 
           echo "::set-output name=repos::$repos"
       - name: find deleted / archived repositories
+        if: ${{ steps.repos.outputs.repos != '[]' }}
         run: |
           status=0
           while read config; do


### PR DESCRIPTION
This fixes stale check on PRs. Previously, we didn't account for a situation where `configs/*.json` is modified but none of the targets are removed/added.