### PR TITLE
Add option to skip `32-bit` go test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ This check will be run in repositories that set `gogenerate` to `true` in `.gith
 Note that depending on the code generators used, it might be necessary to [install those first](#additional-setup-steps).
 The generators must also be deterministic, to prevent CI from getting different results each time.
 
+`go-test` offers an option to completely disable running 32-bit tests.
+This option is useful when a project or its upstream dependencies are not 32-bit compatible.
+Typically, such tests can be disabled using [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints).
+However, the constraints must be set per go file, which can be cumbersome for a project with many files.
+Using this option, 32-bit tests can be skipped entirely without having to specify build constraints per file.
+
+To completely disable running 32-bit tests set `skip32bit` to `true` in `.github/workflows/go-test-config.json`:
+```json
+{
+  "skip32bit": true
+}
+```
+
 ## Technical Preview
 
 You can opt-in to receive early updates from the `next` branch in-between official Unified CI releases.

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -10,6 +10,7 @@ jobs:
         go: [ "1.18.x", "1.19.x" ]
     env:
       COVERAGES: ""
+      SKIP32BIT: false
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
@@ -34,6 +35,13 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
+      - name: Read config
+        if: hashFiles('./.github/workflows/go-test-config.json') != ''
+        shell: bash
+        run: |
+          if jq -re .skip32bit ./.github/workflows/go-test-config.json; then
+            echo "SKIP32BIT=true" >> $GITHUB_ENV
+          fi
       - name: Run tests
         uses: protocol/multiple-go-modules@v1.2
         with:
@@ -42,7 +50,7 @@ jobs:
           # this means ./B's coverage will be significantly higher than 0%.
           run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
       - name: Run tests (32 bit)
-        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
+        if: matrix.os != 'macos' && env.SKIP32BIT == 'false' # can't run 32 bit tests on OSX.
         uses: protocol/multiple-go-modules@v1.2
         env:
           GOARCH: 386


### PR DESCRIPTION
Introduce an option to configure `go-test` to allow completely skipping `32-bit` tests.

Fixes #388