### PR TITLE
chore: replace github-api-action-library with inline js

### DIFF
--- a/.github/workflows/add-label-by-query.yml
+++ b/.github/workflows/add-label-by-query.yml
@@ -7,8 +7,12 @@ on:
         description: Query that finds issues or pull requests to which the label should be added
         required: true
       label:
-        description: Label that should be added to issues or pull requests matching the query (leave blank for dry run)
+        description: Label that should be added to issues or pull requests matching the query
+        required: true
+      dry-run:
+        description: If set to true, the workflow will only print expected actions
         required: false
+        default: 'true'
 
 jobs:
   add:
@@ -16,23 +20,41 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.WEB3BOT_GITHUB_TOKEN }}
     steps:
-      - id: content
-        uses: protocol/github-api-action-library/find-content-by-query@v1
+      - name: Add label by query
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUERY: ${{ github.event.inputs.query }}
+          LABEL: ${{ github.event.inputs.label }}
+          DRY_RUN: ${{ github.event.inputs.dry-run }}
+        uses: actions/github-script@v6
         with:
-          query: ${{ github.event.inputs.query }}
-      - run: |
-          while read item; do
-            number="$(jq -r '.number' <<< "$item")"
-            nameWithOwner="$(jq -r '.repository.nameWithOwner' <<< "$item")"
-            if [ -z '${{ github.event.inputs.label }}' ]; then
-              echo "Would have added a label to $nameWithOwner#$number"
-            else
-              if gh issue edit "$number" --repo="$nameWithOwner" --add-label='${{ github.event.inputs.label }}'; then
-                echo "Successfully added label ${{ github.event.inputs.label }} to $nameWithOwner#$number"
-              else
-                echo "Failed to add label ${{ github.event.inputs.label }} to $nameWithOwner#$number"
-                echo "::warning ::$nameWithOwner#$number"
-              fi
-            fi
-          done <<< "$(jq -c '.[]' <<< '${{ steps.content.outputs.issues-or-pull-requests }}')"
-        shell: bash
+          result-encoding: string
+          script: |
+            const items = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: process.env.QUERY
+            })
+            for (const item of items) {
+              const labels = item.labels.map(l => l.name)
+              if (labels.includes(process.env.LABEL)) {
+                core.debug(`Skipping because ${item.url} already contains ${process.env.LABEL}`)
+                continue
+              }
+              if (process.env.DRY_RUN === 'true') {
+                core.info(`Would have added ${process.env.LABEL} label to ${item.url}`)
+                continue
+              }
+              const [_, owner, repo] = item.url.match(/repos\/(.+?)\/(.+?)\/issues/)
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  labels: [{
+                    name: process.env.LABEL
+                  }]
+                })
+                core.info(`Added ${process.env.LABEL} label to ${item.url}`)
+              } catch(error) {
+                core.error(`Couldn't add ${process.env.LABEL} label to ${item.url}, got: ${error}`)
+              }
+            }


### PR DESCRIPTION
I want to deprecate https://github.com/protocol/github-api-action-library. To make it possible, in this PR I replace usage of `protocol/github-api-action-library/find-content-by-query@v1` + some bash with inline JS script. If we end up using it more, we could move the script outside the YAML.

I tested the new version of this workflow in https://github.com/protocol/.github/actions/workflows/add-label-by-query.yml