### PR TITLE
Run at most 1 dispatch job per ref

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [ master, testing ]
   workflow_dispatch:
+  
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   # Number of repositories in a batch.


### PR DESCRIPTION
Resolves #374

We don't want to run dispatch in parallel because they would be overwriting each other. 