### PR TITLE
fix: check if git tag returns any results

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -52,13 +52,16 @@ jobs:
         run: |
           git fetch origin --tags
           go install github.com/marten-seemann/semver-highest@fcdc98f8820ff0e6613c1bee071c096febd98dbf
-          v=$(semver-highest -target ${{ env.VERSION }} -versions $(git tag | paste -sd , -))
-          status=$?
-          if [[ $status != 0 ]]; then
-            echo $v
-            exit $status
+          vs=$(git tag | paste -sd , -)
+          if [[ ! -z "$vs" ]]; then
+            v=$(semver-highest -target ${{ env.VERSION }} -versions "$vs")
+            status=$?
+            if [[ $status != 0 ]]; then
+              echo $v
+              exit $status
+            fi
+            echo "COMPARETO=$v" >> $GITHUB_ENV
           fi
-          echo "COMPARETO=$v" >> $GITHUB_ENV
       - name: Post output
         if: env.TAG_EXISTS == 'false' && env.COMPARETO == ''
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1


### PR DESCRIPTION
Resolves #381 

This PR adds a check if `git tag | paste -sd , -` returns a non-empty string. It looks for a version to compare to only if the return value is non-empty. 