### PR TITLE
Enable unified CI for `ipni/heyfil` go project

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -331,6 +331,9 @@
       "target": "ipld/go-storethehash"
     },
     {
+      "target": "ipni/heyfil"
+    },
+    {
       "target": "libp2p/dht-tracer1"
     },
     {


### PR DESCRIPTION
Enable unified CI builds for `ipni/heyfil` go project; See:
- https://github.com/ipni/heyfil