### PR TITLE
use next as a source for go-ds-pebble

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -124,7 +124,8 @@
       "target": "ipfs/go-ds-measure"
     },
     {
-      "target": "ipfs/go-ds-pebble"
+      "target": "ipfs/go-ds-pebble",
+      "source_ref": "next"
     },
     {
       "target": "ipfs/go-ds-redis"


### PR DESCRIPTION
We're putting `go-ds-pebble` on Unified CI updates from `next` branch (using https://github.com/protocol/.github#technical-preview feature) to be able to skip 32bit tests (https://github.com/protocol/.github/pull/412).

We're going to clear the `source_ref` setting so that `go-ds-pebble` gets updates from `master` again during the next major Unified CI release. 