### PR TITLE
fix: test on lts node

### DIFF
--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [16]
+        node: [lts/*]
       fail-fast: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 16 is no longer lts, instead use `lts/*` as the version to always get active lts, version 18.x at the time of writing.