### PR TITLE
Add `indexstar` and `index-observer` to unified CI for Golang

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -338,6 +338,12 @@
       "target": "ipni/heyfil"
     },
     {
+      "target": "ipni/index-observer"
+    },
+    {
+      "target": "ipni/indexstar"
+    },
+    {
       "target": "libp2p/dht-tracer1"
     },
     {


### PR DESCRIPTION
Add `indexstar` and `index-observer` from IPNI org to unified CI for
 Golang.