### PR TITLE
use GHA template expansion only in env/arg in release-check workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -74,7 +74,7 @@ jobs:
         name: run git diff on go.mod file(s)
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
         env:
-          PREV_VERSION: steps.prev.outputs.version
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
         run: |
           # First get the diff for the go.mod file in the root directory...
           output=$(git diff "$PREV_VERSION..HEAD" -- './go.mod')
@@ -89,7 +89,7 @@ jobs:
         name: Run gorelease
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
         env:
-          PREV_VERSION: steps.prev.outputs.version
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
         # see https://github.com/golang/exp/commits/master/cmd/gorelease
         run: |
           go mod download
@@ -100,7 +100,7 @@ jobs:
         name: Check Compatibility
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
         env:
-          PREV_VERSION: steps.prev.outputs.version
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
         run: |
           go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
           output=$(gocompat compare --go1compat --git-refs="$PREV_VERSION..HEAD" ./... || true)

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -8,41 +8,42 @@ on: [ workflow_call ]
 jobs:
   releaser:
     runs-on: ubuntu-latest
-    env:
-      TAG_EXISTS: "true"
-      VERSION: "" # the version number read from version.json
-      COMPARETO: "" # the version number to compare this version to
-      GORELEASE: ""
-      GOCOMPAT: ""
-      GOMODDIFF: ""
-      RELEASE_BRANCH_NOTE: ""
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19.x"
-      - name: Determine version
+      - id: version
+        name: Determine version
         if: hashFiles('version.json')
-        run: echo "VERSION=$(jq -r .version version.json)" >> $GITHUB_ENV
-      - name: Check if the tag already exists
+        run: echo "version=$(jq -r .version version.json)" >> $GITHUB_OUTPUT
+      - id: tag
+        name: Check if the tag already exists
         # Check if a git tag for the version (as read from version.json) exists
         # If that is the case, we don't need to run the rest of the workflow.
-        if: env.VERSION != ''
+        if: steps.version.outputs.version != ''
         run: |
           git fetch origin --tags
           status=0
-          git rev-list $VERSION &> /dev/null || status=$?
-          if [[ $status != 0 ]]; then
-            echo "TAG_EXISTS=false" >> $GITHUB_ENV
+          git rev-list "$VERSION" &> /dev/null || status=$?
+          if [[ $status == 0 ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
       - name: Install semver (node command line tool)
-        if: env.TAG_EXISTS == 'false'
+        if: steps.tag.outputs.exists == 'false'
         run: npm install -g "https://github.com/npm/node-semver#e79ac3a450e8bb504e78b8159e3efc7089569" # v7.3.5
       - name: Check version
-        if: env.TAG_EXISTS == 'false'
-        run: semver ${{ env.VERSION }} # fails if the version is not a valid semver version (e.g. v0.1 would fail)
-      - name: Determine version number to compare to
-        if: env.TAG_EXISTS == 'false'
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: semver "$VERSION" # fails if the version is not a valid semver version (e.g. v0.1 would fail)
+      - id: prev
+        name: Determine version number to compare to
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         # We need to determine the version number we want to compare to,
         # taking into account that this might be a (patch) release on a release branch.
         # Example:
@@ -52,94 +53,119 @@ jobs:
         run: |
           git fetch origin --tags
           go install github.com/marten-seemann/semver-highest@fcdc98f8820ff0e6613c1bee071c096febd98dbf
-          v=$(semver-highest -target ${{ env.VERSION }} -versions $(git tag | paste -sd , -))
+          v=$(semver-highest -target "$VERSION" -versions $(git tag | paste -sd , -))
           status=$?
           if [[ $status != 0 ]]; then
             echo $v
             exit $status
           fi
-          echo "COMPARETO=$v" >> $GITHUB_ENV
+          echo "version=$v" >> $GITHUB_OUTPUT
       - name: Post output
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO == ''
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version == ''
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
         with:
           header: release-check
           recreate: true
           message: |
-            Suggested version: `${{ env.VERSION }}`
+            Suggested version: `${{ steps.version.outputs.version }}`
 
             This is the first release of this module.
-      - name: run git diff on go.mod file(s)
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
+      - id: git-diff
+        name: run git diff on go.mod file(s)
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: steps.prev.outputs.version
         run: |
           # First get the diff for the go.mod file in the root directory...
-          output=$(git diff ${{ env.COMPARETO }}..HEAD -- './go.mod')
+          output=$(git diff "$PREV_VERSION..HEAD" -- './go.mod')
           # ... then get the diff for all go.mod files in subdirectories.
           # Note that this command also finds go.mod files more than one level deep in the directory structure.
-          output+=$(git diff ${{ env.COMPARETO }}..HEAD -- '*/go.mod')
+          output+=$(git diff "$PREV_VERSION..HEAD" -- '*/go.mod')
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "GOMODDIFF<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
-      - name: Run gorelease
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
+          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+      - id: gorelease
+        name: Run gorelease
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: steps.prev.outputs.version
         # see https://github.com/golang/exp/commits/master/cmd/gorelease
         run: |
           go mod download
           go install golang.org/x/exp/cmd/gorelease@b4e88ed8e8aab63a9aa9a52276782ebbc547adef
-          output=$((gorelease -base ${{ env.COMPARETO }}) 2>&1 || true)
-          printf "GORELEASE<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
-      - name: Check Compatibility
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
+          output=$((gorelease -base "$PREV_VERSION") 2>&1 || true)
+          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+      - id: gocompat
+        name: Check Compatibility
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: steps.prev.outputs.version
         run: |
           go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
-          output=$(gocompat compare --go1compat --git-refs="${{ env.COMPARETO }}..HEAD" ./... || true)
+          output=$(gocompat compare --go1compat --git-refs="$PREV_VERSION..HEAD" ./... || true)
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "GOCOMPAT<<EOF\n%s\nEOF" "$output" >> $GITHUB_ENV
-      - run: |
-          echo "RELEASE_BRANCH_NOTE<<EOF
+          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+      - id: footnote
+        if: github.base_ref != github.event.repository.default_branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          echo "output<<EOF
           ---
-          ## Cutting a Release (when not on \`${{ github.event.repository.default_branch }}\`)
+          ## Cutting a Release (when not on \`$DEFAULT_BRANCH\`)
 
-          This PR is targeting \`${{ github.base_ref }}\`, which is not the default branch.
+          This PR is targeting \`$BASE_REF\`, which is not the default branch.
           If you wish to cut a release once this PR is merged, please add the \`release\` label to this PR.
           EOF" >> $GITHUB_ENV
-        if: github.base_ref != github.event.repository.default_branch
-      - run: |
-          echo 'MESSAGE<<EOF
-          Suggested version: `${{ env.VERSION }}`
-          Comparing to: [`${{ env.COMPARETO }}`](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ env.COMPARETO }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ env.COMPARETO }}..${{ github.event.pull_request.head.label }}))
+      - id: message
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
+          BASE_HTML_URL: ${{ github.event.pull_request.base.repo.html_url }}
+          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+          GIT_DIFF: ${{ steps.git-diff.outputs.output }}
+          GORELEASE: ${{ steps.gorelease.outputs.output }}
+          GOCOMPAT: ${{ steps.gocompat.outputs.output }}
+          FOOTNOTE: ${{ steps.footnote.outputs.output }}
+        run: |
+          echo 'output<<EOF
+          Suggested version: `$VERSION`
+          Comparing to: [`$PREV_VERSION`]($BASE_HTML_URL/releases/tag/$PREV_VERSION) ([diff]($HTML_URL/compare/$PREV_VERSION..$HEAD_LABEL))
 
           Changes in `go.mod` file(s):
           ```diff
-          ${{ env.GOMODDIFF }}
+          $GIT_DIFF
           ```
 
           `gorelease` says:
           ```
-          ${{ env.GORELEASE }}
+          $GORELEASE
           ```
 
           `gocompat` says:
           ```
-          ${{ env.GOCOMPAT }}
+          $GOCOMPAT
           ```
-          ${{ env.RELEASE_BRANCH_NOTE }}
-          EOF' >> $GITHUB_ENV
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != ''
+          $FOOTNOTE
+          EOF' >> $GITHUB_OUTPUT
       - name: Post message on PR
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != '' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: release-check
           recreate: true
-          message: ${{ env.MESSAGE }}
+          message: ${{ steps.message.outputs.output }}
       - name: Set a notice message on run
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != '' && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          MESSAGE: ${{ steps.message.outputs.output }}
         run: |
           message="${MESSAGE//'%'/'%25'}"
           message="${message//$'\n'/'%0A'}"
           message="${message//$'\r'/'%0D'}"
           echo "::notice ::$message"
-        if: env.TAG_EXISTS == 'false' && env.COMPARETO != '' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -114,12 +114,12 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          echo "output<<EOF
+          echo 'output<<EOF
           ---
-          ## Cutting a Release (when not on \`$DEFAULT_BRANCH\`)
+          ## Cutting a Release (when not on `'"$DEFAULT_BRANCH"'`)
 
-          This PR is targeting \`$BASE_REF\`, which is not the default branch.
-          If you wish to cut a release once this PR is merged, please add the \`release\` label to this PR.
+          This PR is targeting `'"$BASE_REF"'`, which is not the default branch.
+          If you wish to cut a release once this PR is merged, please add the `release` label to this PR.
           EOF" >> $GITHUB_ENV
       - id: message
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
@@ -134,24 +134,24 @@ jobs:
           FOOTNOTE: ${{ steps.footnote.outputs.output }}
         run: |
           echo 'output<<EOF
-          Suggested version: `$VERSION`
-          Comparing to: [`$PREV_VERSION`]($BASE_HTML_URL/releases/tag/$PREV_VERSION) ([diff]($HTML_URL/compare/$PREV_VERSION..$HEAD_LABEL))
+          Suggested version: `'"$VERSION"'`
+          Comparing to: [`'"$PREV_VERSION"'`]('"$BASE_HTML_URL"'/releases/tag/'"$PREV_VERSION"') ([diff]('"$HTML_URL"'/compare/'"$PREV_VERSION"'..'"$HEAD_LABEL"'))
 
           Changes in `go.mod` file(s):
           ```diff
-          $GIT_DIFF
+          '"$GIT_DIFF"'
           ```
 
           `gorelease` says:
           ```
-          $GORELEASE
+          '"$GORELEASE"'
           ```
 
           `gocompat` says:
           ```
-          $GOCOMPAT
+          '"$GOCOMPAT"'
           ```
-          $FOOTNOTE
+          '"$FOOTNOTE"'
           EOF' >> $GITHUB_OUTPUT
       - name: Post message on PR
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,8 @@ jobs:
   releaser:
     runs-on: ubuntu-latest
     steps:
+      - run: echo "EOF=EOF$RANDOM" >> $GITHUB_ENV
+        shell: bash
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
@@ -84,7 +86,7 @@ jobs:
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
       - id: gorelease
         name: Run gorelease
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
@@ -95,7 +97,7 @@ jobs:
           go mod download
           go install golang.org/x/exp/cmd/gorelease@b4e88ed8e8aab63a9aa9a52276782ebbc547adef
           output=$((gorelease -base "$PREV_VERSION") 2>&1 || true)
-          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
       - id: gocompat
         name: Check Compatibility
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
@@ -107,20 +109,20 @@ jobs:
           if [[ -z "$output" ]]; then
             output="(empty)"
           fi
-          printf "output<<EOF\n%s\nEOF" "$output" >> $GITHUB_OUTPUT
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
       - id: footnote
         if: github.base_ref != github.event.repository.default_branch
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          echo 'output<<EOF
+          echo 'output<<'"$EOF"'
           ---
           ## Cutting a Release (when not on `'"$DEFAULT_BRANCH"'`)
 
           This PR is targeting `'"$BASE_REF"'`, which is not the default branch.
           If you wish to cut a release once this PR is merged, please add the `release` label to this PR.
-          EOF" >> $GITHUB_ENV
+          '"$EOF" >> $GITHUB_ENV
       - id: message
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
         env:
@@ -133,7 +135,7 @@ jobs:
           GOCOMPAT: ${{ steps.gocompat.outputs.output }}
           FOOTNOTE: ${{ steps.footnote.outputs.output }}
         run: |
-          echo 'output<<EOF
+          echo 'output<<'"$EOF"'
           Suggested version: `'"$VERSION"'`
           Comparing to: [`'"$PREV_VERSION"'`]('"$BASE_HTML_URL"'/releases/tag/'"$PREV_VERSION"') ([diff]('"$HTML_URL"'/compare/'"$PREV_VERSION"'..'"$HEAD_LABEL"'))
 
@@ -152,7 +154,7 @@ jobs:
           '"$GOCOMPAT"'
           ```
           '"$FOOTNOTE"'
-          EOF' >> $GITHUB_OUTPUT
+          '"$EOF" >> $GITHUB_OUTPUT
       - name: Post message on PR
         uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != '' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
###### Description

This PR modified `release-check.yml`. It changes it in the following ways:
- do not use global `GITHUB_ENV`
- do use steps' `GITHUB_OUTPUT`s
- do not use template expansion (`${{}}`) inside `run:` blocks
- do make other steps' outputs available to a step either through `env:` block or through `with:` block

As a result, we end up with a workflow where each step is explicitly given context. It is also given only what it requires. Finally, it is less prone to script/env var injection (we're taking in user input through `version.json@version`).

###### Testing
- [x] https://github.com/galargh/go-bitswap/actions/runs/3894978601/jobs/6649871670 + https://github.com/galargh/go-bitswap/pull/1#issuecomment-1379221832