### PR TITLE
Set source reference to `next` for some IPNI projects

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -341,10 +341,12 @@
       "target": "ipni/caskadht"
     },
     {
-      "target": "ipni/dhstore"
+      "target": "ipni/dhstore",
+      "source_ref": "next"
     },
     {
-      "target": "ipni/go-indexer-core"
+      "target": "ipni/go-indexer-core",
+      "source_ref": "next"
     },
     {
       "target": "ipni/go-naam"
@@ -362,7 +364,8 @@
       "target": "ipni/indexstar"
     },
     {
-      "target": "ipni/storetheindex"
+      "target": "ipni/storetheindex",
+      "source_ref": "next"
     },
     {
       "target": "libp2p/dht-tracer1"


### PR DESCRIPTION
The IPNI projects depending on pebble are unable to support 32-bit tests. Move those repos to `next` source reference since it has support for skipping 32-bit tests implemented.

See:
 - https://github.com/protocol/.github/issues/388