### PR TITLE
feat: allow skipping go-test on certain OSes

### DIFF
--- a/.github/actions/read-config/action.yml
+++ b/.github/actions/read-config/action.yml
@@ -16,3 +16,7 @@ runs:
         path="./${path#*/*/}-config.json"
         printf "json<<$eof\n%s\n$eof" "$(cat "$path" || echo '{}')" >> $GITHUB_OUTPUT
       shell: bash
+    - env:
+        CONFIG: ${{ steps.config.outputs.json }}
+      run: echo "$CONFIG"
+      shell: bash

--- a/.github/actions/read-config/action.yml
+++ b/.github/actions/read-config/action.yml
@@ -1,0 +1,18 @@
+name: read config
+description: Reads workflow config
+
+outputs:
+  json:
+    description: JSON config
+    value: ${{ steps.config.outputs.json }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: config
+      run: |
+        eof="EOF$RANDOM"
+        path="${GITHUB_WORKFLOW_REF%.yml@*}"
+        path="./${path#*/*/}-config.json"
+        printf "json<<$eof\n%s\n$eof" "$(cat "$path" || echo '{}')" >> $GITHUB_OUTPUT
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ To completely disable running 32-bit tests set `skip32bit` to `true` in `.github
 }
 ```
 
+If your project cannot be built on one of the supported operating systems, you can disable it by setting `skipOSes` to a list of operating systems in `.github/workflows/go-test-config.json`:
+```json
+{
+  "skipOSes": ["windows", "macos"]
+}
+```
+
 ## Technical Preview
 
 You can opt-in to receive early updates from the `next` branch in-between official Unified CI releases.

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -5,24 +5,18 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     name: All
-    env:
-      RUNGOGENERATE: false
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - id: config
+        uses: protocol/.github/.github/actions/read-config@master
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19.x"
       - name: Run repo-specific setup
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''
-      - name: Read config
-        if: hashFiles('./.github/workflows/go-check-config.json') != ''
-        run: |
-          if jq -re .gogenerate ./.github/workflows/go-check-config.json; then
-            echo "RUNGOGENERATE=true" >> $GITHUB_ENV
-          fi
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@376210a89477dedbe6fdc4484b233998650d7b3c # 2022.1.3 (v0.3.3)
       - name: Check that go.mod is tidy
@@ -57,7 +51,7 @@ jobs:
             staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
       - name: go generate
         uses: protocol/multiple-go-modules@v1.2
-        if: (success() || failure()) && env.RUNGOGENERATE == 'true'
+        if: (success() || failure()) && fromJSON(steps.config.outputs.json).gogenerate == true
         with:
           run: |
             git clean -fd # make sure there aren't untracked files / directories

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests (32 bit)
         # can't run 32 bit tests on OSX.
         if: matrix.os != 'macos' &&
-          fromJSON(steps.config.outputs.json).skip32bit != true
+          fromJSON(steps.config.outputs.json).skip32bit != true &&
           contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
         env:

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -37,6 +37,7 @@ jobs:
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
       - name: Run tests
+        if: contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
         with:
           # Use -coverpkg=./..., so that we include cross-package coverage.
@@ -44,7 +45,10 @@ jobs:
           # this means ./B's coverage will be significantly higher than 0%.
           run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
       - name: Run tests (32 bit)
-        if: matrix.os != 'macos' && fromJSON(steps.config.outputs.json).skip32bit != true # can't run 32 bit tests on OSX.
+        # can't run 32 bit tests on OSX.
+        if: matrix.os != 'macos' &&
+          fromJSON(steps.config.outputs.json).skip32bit != true
+          contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
         env:
           GOARCH: 386
@@ -53,7 +57,9 @@ jobs:
             export "PATH=${{ env.PATH_386 }}:$PATH"
             go test -v -shuffle=on ./...
       - name: Run tests with race detector
-        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+        # speed things up. Windows and OSX VMs are slow
+        if: matrix.os == 'ubuntu' &&
+          contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
         with:
           run: go test -v -race ./...

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -10,13 +10,14 @@ jobs:
         go: [ "1.18.x", "1.19.x" ]
     env:
       COVERAGES: ""
-      SKIP32BIT: false
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - id: config
+        uses: protocol/.github/.github/actions/read-config@master
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
@@ -35,13 +36,6 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
-      - name: Read config
-        if: hashFiles('./.github/workflows/go-test-config.json') != ''
-        shell: bash
-        run: |
-          if jq -re .skip32bit ./.github/workflows/go-test-config.json; then
-            echo "SKIP32BIT=true" >> $GITHUB_ENV
-          fi
       - name: Run tests
         uses: protocol/multiple-go-modules@v1.2
         with:
@@ -50,7 +44,7 @@ jobs:
           # this means ./B's coverage will be significantly higher than 0%.
           run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
       - name: Run tests (32 bit)
-        if: matrix.os != 'macos' && env.SKIP32BIT == 'false' # can't run 32 bit tests on OSX.
+        if: matrix.os != 'macos' && fromJSON(steps.config.outputs.json).skip32bit != true # can't run 32 bit tests on OSX.
         uses: protocol/multiple-go-modules@v1.2
         env:
           GOARCH: 386


### PR DESCRIPTION
Resolves #349

#### Description

This PR allows configuring uCI to skip go-test on certain OSes by providing a list of OSes that should be skipped in `go-test-config.json` under `skipOSes` key.

If there's a match, the most time consuming steps of the workflow will be skipped. The job itself won't because that would require us to split the job in two, where one would be used only for figuring out whether the other should be skipped, and we don't want to introduce the overhead of starting up two jobs. 

#### Testing

- [x] tested on this commit - https://github.com/protocol/.github-test-target/commit/6206a6fa8bab0f616f83d53713e417dfe4fbc9e9