### PR TITLE
feat: create gh releases in release-check/releaser workflows

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -69,16 +69,6 @@ jobs:
             fi
             echo "version=$v" >> $GITHUB_OUTPUT
           fi
-      - name: Post output
-        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version == ''
-        uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
-        with:
-          header: release-check
-          recreate: true
-          message: |
-            Suggested version: `${{ steps.version.outputs.version }}`
-
-            This is the first release of this module.
       - id: git-diff
         name: run git diff on go.mod file(s)
         if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
@@ -117,41 +107,18 @@ jobs:
             output="(empty)"
           fi
           printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
-      - id: footnote
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          BASE_REF: ${{ github.base_ref }}
-          GITHUB_TOKEN: ${{ github.token }}
-          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
-        run: |
-          output=''
-          if [[ "$DEFAULT_BRANCH" != "$BASE_REF" ]]; then
-            output+='
-          ## Cutting a Release (when not on `'"$DEFAULT_BRANCH"'`)
-
-          This PR is targeting `'"$BASE_REF"'`, which is not the default branch.
-          If you wish to cut a release once this PR is merged, please add the `release` label to this PR.
-          '
-          fi
-          diff="$(gh api -X GET "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_LABEL" --jq '.files | map(.filename) | map(select(test("^(version\\.json|.*\\.md)$") | not)) | .[]')"
-          if [[ "$diff" != "" ]]; then
-            output+='
-          ## Cutting a Release (and modifying non-markdown files)
-
-          This PR is modifying both `version.json` and non-markdown files.
-          The Release Checker is not able to analyse files that are not checked in to `'"$BASE_REF"'`. This might cause the above analysis to be inaccurate.
-          Please consider performing all the code changes in a separate PR before cutting the release.
-          '
-          fi
-          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
-      - name: Post message on PR
-        uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
-        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+      - id: release
+        if: github.event.repository == github.repository
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
-          header: release-check
-          recreate: true
-          message: |
+          draft: true
+          tag_name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+      - id: message
+        env:
+          HEADER: |
             Suggested version: `${{ steps.version.outputs.version }}`
+          BODY: |
             Comparing to: [${{ steps.prev.outputs.version }}](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ steps.prev.outputs.version }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ steps.prev.outputs.version }}..${{ github.event.pull_request.head.label }}))
 
             Changes in `go.mod` file(s):
@@ -168,4 +135,73 @@ jobs:
             ```
             ${{ steps.gocompat.outputs.output }}
             ```
-            ${{ steps.footnote.outputs.output }}
+
+          BODY_ALT: |
+            This is the first release of this module.
+
+          RELEASE_BRANCH_NOTICE: |
+            ## Cutting a Release (when not on `${{ github.event.repository.default_branch }}`)
+
+            This PR is targeting `${{ github.base_ref }}`, which is not the default branch.
+            If you wish to cut a release once this PR is merged, please add the `release` label to this PR.
+
+          DIFF_NOTICE: |
+            ## Cutting a Release (and modifying non-markdown files)
+
+            This PR is modifying both `version.json` and non-markdown files.
+            The Release Checker is not able to analyse files that are not checked in to `${{ github.base_ref }}`. This might cause the above analysis to be inaccurate.
+            Please consider performing all the code changes in a separate PR before cutting the release.
+
+          RELEASE_NOTICE: |
+            ## Automatically created GitHub Release
+
+            A [draft GitHub Release]() has been created.
+            It is going to be published when this PR is merged.
+            You can modify its' body to include any release notes you wish to include with the release.
+
+          RELEASE_NOTICE_ALT: |
+            ## Automatically created GitHub Release
+
+            Pre-creating GitHub Releases on release PRs initiated from forks is not supported.
+            If you wish to prepare release notes yourself, you should create a draft GitHub Release for tag `${{}}` manually.
+            The draft GitHub Release is going to be published when this PR is merged.
+            If you choose not to create a draft GitHub Release, a published GitHub Released is going to be created when this PR is merged.
+
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+          HEAD_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          echo "output<<$EOF" >> $GITHUB_OUTPUT
+
+          echo "$HEADER" >> $GITHUB_OUTPUT
+
+          if [[ "$PREV_VERSION" != "" ]]; then
+            echo "$BODY" >> $GITHUB_OUTPUT
+          else
+            echo "$BODY_ALT" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$DEFAULT_BRANCH" != "$BASE_REF" ]]; then
+            echo "$RELEASE_BRANCH_NOTICE" >> $GITHUB_OUTPUT
+          fi
+
+          diff="$(gh api -X GET "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_LABEL" --jq '.files | map(.filename) | map(select(test("^(version\\.json|.*\\.md)$") | not)) | .[]')"
+          if [[ "$diff" != "" ]]; then
+            echo "$DIFF_NOTICE" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$GITHUB_REPOSITORY" == "$HEAD_FULL_NAME" ]]; then
+            echo "$RELEASE_NOTICE" >> $GITHUB_OUTPUT
+          else
+            echo "$RELEASE_NOTICE_ALT" >> $GITHUB_OUTPUT
+          fi
+
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Post message on PR
+        uses: marocchino/sticky-pull-request-comment@82e7a0d3c51217201b3fedc4ddde6632e969a477 # v2.1.1
+        if: steps.tag.outputs.exists == 'false'
+        with:
+          header: release-check
+          recreate: true
+          message: ${{ steps.message.outputs.output }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -108,7 +108,7 @@ jobs:
           fi
           printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
       - id: release
-        if: github.event.repository == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: true

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -155,7 +155,7 @@ jobs:
           RELEASE_NOTICE: |
             ## Automatically created GitHub Release
 
-            A [draft GitHub Release]() has been created.
+            A [draft GitHub Release](${{ steps.release.outputs.url }}) has been created.
             It is going to be published when this PR is merged.
             You can modify its' body to include any release notes you wish to include with the release.
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -172,6 +172,7 @@ jobs:
           HEAD_LABEL: ${{ github.event.pull_request.head.label }}
           HEAD_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_TOKEN: ${{ github.token }}
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
         run: |
           echo "output<<$EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -163,7 +163,7 @@ jobs:
             ## Automatically created GitHub Release
 
             Pre-creating GitHub Releases on release PRs initiated from forks is not supported.
-            If you wish to prepare release notes yourself, you should create a draft GitHub Release for tag `${{}}` manually.
+            If you wish to prepare release notes yourself, you should create a draft GitHub Release for tag `${{ steps.version.outputs.version }}` manually.
             The draft GitHub Release is going to be published when this PR is merged.
             If you choose not to create a draft GitHub Release, a published GitHub Released is going to be created when this PR is merged.
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -171,6 +171,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_LABEL: ${{ github.event.pull_request.head.label }}
           HEAD_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           echo "output<<$EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -109,7 +109,7 @@ jobs:
           printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
       - id: release
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
         with:
           draft: true
           tag_name: ${{ steps.version.outputs.version }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -9,9 +9,6 @@ jobs:
       - id: version
         name: Determine version
         run: echo "version=$(jq -r .version version.json)" >> $GITHUB_OUTPUT
-      - name: Create a release, if we're on the default branch
-        run: echo "CREATETAG=true" >> $GITHUB_ENV
-        if: env.DEFAULT_BRANCH == github.ref
       - id: pr
         name: Determine if this commit is a merged PR (if we're not on a default branch)
         if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -15,9 +15,13 @@ jobs:
         uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - id: labels
+        env:
+          LABELS: ${{ steps.pr.outputs.labels }}
+        run: echo "labels=$(jq -nc 'env.LABELS | split("\n")')" >> $GITHUB_OUTPUT
       - name: Create release
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
-          contains(fromJSON(steps.pr.outputs.labels || '[]'), 'release')
+          contains(fromJSON(steps.labels.outputs.labels), 'release')
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: false

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -4,39 +4,25 @@ on: [ workflow_call ]
 jobs:
   releaser:
     runs-on: ubuntu-latest
-    env:
-      VERSION: ""
-      CREATETAG: "false"
-      DEFAULT_BRANCH: ""
     steps:
       - uses: actions/checkout@v3
-      - name: Determine version
-        run: echo "VERSION=$(jq -r .version version.json)" >> $GITHUB_ENV
-      - name: Determine branch
-        run: echo "DEFAULT_BRANCH=refs/heads/${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+      - id: version
+        name: Determine version
+        run: echo "version=$(jq -r .version version.json)" >> $GITHUB_OUTPUT
       - name: Create a release, if we're on the default branch
         run: echo "CREATETAG=true" >> $GITHUB_ENV
         if: env.DEFAULT_BRANCH == github.ref
-      - name: Determine if this commit is a merged PR (if we're not on a default branch)
-        if: env.DEFAULT_BRANCH != github.ref
-        id: getmergedpr
+      - id: pr
+        name: Determine if this commit is a merged PR (if we're not on a default branch)
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check if the "release" label was set on the PR
-        if: steps.getmergedpr.outputs.number != '' && env.DEFAULT_BRANCH != github.ref
-        run: |
-          while IFS= read -r label; do
-            if [[ "$label" == "release" ]]; then
-              echo "CREATETAG=true" >> $GITHUB_ENV
-              break
-            fi
-          done <<< "${{ steps.getmergedpr.outputs.labels }}"
       - name: Create release
-        if: env.CREATETAG == 'true'
-        run: |
-          git fetch origin --tags
-          if ! $(git rev-list ${{ env.VERSION}}.. &> /dev/null); then
-            git tag ${{ env.VERSION }}
-            git push --tags
-          fi
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+          contains(fromJSON(steps.pr.outputs.labels), 'release')
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: false
+          tag_name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -17,7 +17,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
-          contains(fromJSON(steps.pr.outputs.labels), 'release')
+          contains(fromJSON(steps.pr.outputs.labels || '[]'), 'release')
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: false

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create release
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
           contains(fromJSON(steps.labels.outputs.labels), 'release')
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
         with:
           draft: false
           tag_name: ${{ steps.version.outputs.version }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,9 +30,13 @@ Every Go repository contains a `version.json` file in the root directory:
 This version file defines the currently released version.
 
 When cutting a new release, open a Pull Request that bumps the version number and have it review by your team mates.
-The [release check workflow](.github/workflows/release-check.yml) will comment on the PR and post useful information (the output of `gorelease`, `gocompat` and a diff of the `go.mod` files(s)).
+The [release check workflow](.github/workflows/release-check.yml) will create a draft GitHub Release (_if the workflow was not initiated by a PR from a fork_) and post a link to it along with other useful information (the output of `gorelease`, `gocompat` and a diff of the `go.mod` files(s)).
 
-As soon as the PR is merged into the default branch, the [releaser workflow](.github/workflows/releaser.yml) is run. This workflow cuts a new release on CI and pushes the tag.
+As soon as the PR is merged into the default branch, the [releaser workflow](.github/workflows/releaser.yml) is run. This workflow either publishes the draft GitHub Release created by the release check workflow or creates a published GitHub Release if it doesn't exist yet. This, in turn, will create a new Git tag and push it to the repository.
+
+### Modifying GitHub Release
+
+All modification you make to the draft GitHub Release created by the release check workflow will be preserved. You can change its' name and body to describe the release in more detail.
 
 ### Using a Release Branch
 


### PR DESCRIPTION
#### Description

Resolves #228 by making release workflows create GitHub Releases.

###### release-check

This PR makes release-check create a **draft** GitHub Release and include a link to it in a comment IF the PR is **NOT** from fork. Otherwise, it suggests creating a draft GitHub Release in the comment.

###### releaser

This PR makes releaser either publish the draft GitHub Release if it exists or create a GitHub Release otherwise.

#### Testing

- [x] https://github.com/protocol/.github-test-target/pull/46
- [x] https://github.com/protocol/.github-test-target/pull/44