### PR TITLE
feat: allow disabling coverage and shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Most repositories won't need any customization, and the workflows defined here w
 
 Some aspects of Unified CI workflows are configurable through [configuration variables](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository).
 
-You can customise the runner type for `go-test` through `UCI_GO_TEST_RUNNER_UBUNTU`, `UCI_GO_TEST_RUNNER_WINDOWS` and `UCI_GO_TEST_RUNNER_MACOS` configuration variables. This option will be useful for repositories wanting to use more powerful, [PL self-hosted GitHub Actions runners](https://github.com/pl-strflt/tf-aws-gh-runner).
+You can customise the runner type for `go-test` through `UCI_GO_TEST_RUNNER_UBUNTU`, `UCI_GO_TEST_RUNNER_WINDOWS` and `UCI_GO_TEST_RUNNER_MACOS` configuration variables. This option will be useful for repositories wanting to use more powerful, [PL self-hosted GitHub Actions runners](https://github.com/pl-strflt/tf-aws-gh-runner). Make sure the value of the variable is valid JSON.
 
 #### Setup Actions
 
@@ -69,6 +69,14 @@ If your project cannot be built on one of the supported operating systems, you c
 ```json
 {
   "skipOSes": ["windows", "macos"]
+}
+```
+
+You can also control whether the tests are shuffled and if coverage is collected by setting `noShuffle` and `noCoverage` to `true` in `.github/workflows/go-test-config.json`:
+```json
+{
+  "noShuffle": true,
+  "noCoverage": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,6 @@ If your project cannot be built on one of the supported operating systems, you c
 }
 ```
 
-You can also control whether the tests are shuffled and if coverage is collected by setting `noShuffle` and `noCoverage` to `true` in `.github/workflows/go-test-config.json`:
-```json
-{
-  "noShuffle": true,
-  "noCoverage": true
-}
-```
-
 ## Technical Preview
 
 You can opt-in to receive early updates from the `next` branch in-between official Unified CI releases.

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -9,7 +9,9 @@ jobs:
         os: [ "ubuntu", "windows", "macos" ]
         go: ${{{ config.go.versions }}}
     env:
-      COVERAGES: ""
+      GOTESTFLAGS: -shuffle=on -cover -coverprofile=module-coverage.txt -coverpkg=./...
+      GO386FLAGS: -shuffle=on
+      GORACEFLAGS: -shuffle=on
     runs-on: ${{ fromJSON(vars[format('UCI_GO_TEST_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
@@ -36,26 +38,13 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
-      - id: args
-        env:
-          NO_SHUFFLE: ${{ fromJSON(steps.config.outputs.json).noShuffle }}
-          NO_COVER: ${{ fromJSON(steps.config.outputs.json).noCover }}
-        shell: bash
-        run: |
-          if [[ "$NO_SHUFFLE" != 'true' ]]; then
-            echo "shuffle=-shuffle=on" >> $GITHUB_OUTPUT
-          fi
-          if [[ "$NO_COVER" != 'true' ]]; then
-            # Use -coverpkg=./..., so that we include cross-package coverage.
-            # If package ./A imports ./B, and ./A's tests also cover ./B,
-            # this means ./B's coverage will be significantly higher than 0%.
-            echo "cover=-cover -coverprofile=module-coverage.txt -coverpkg=./..." >> $GITHUB_OUTPUT
-          fi
       - name: Run tests
         if: contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOFLAGS: ${{ format('{0} {1}', env.GOTESTFLAGS, env.GOFLAGS) }}
         with:
-          run: go test -v ${{ steps.args.outputs.shuffle }} ${{ steps.args.outputs.cover }} ./...
+          run: go test -v ./...
       - name: Run tests (32 bit)
         # can't run 32 bit tests on OSX.
         if: matrix.os != 'macos' &&
@@ -64,24 +53,25 @@ jobs:
         uses: protocol/multiple-go-modules@v1.2
         env:
           GOARCH: 386
+          GOFLAGS: ${{ format('{0} {1}', env.GO386FLAGS, env.GOFLAGS) }}
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -v ${{ steps.args.outputs.shuffle }} ./...
+            go test -v ./...
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow
         if: matrix.os == 'ubuntu' &&
           contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOFLAGS: ${{ format('{0} {1}', env.GORACEFLAGS, env.GOFLAGS) }}
         with:
           run: go test -v -race ./...
       - name: Collect coverage files
         id: coverages
-        if: fromJSON(steps.config.outputs.json).noCover != true
         shell: bash
         run: echo "files=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
       - name: Upload coverage to Codecov
-        if: fromJSON(steps.config.outputs.json).noCover != true
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           files: ${{ steps.coverages.outputs.files }}

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -77,11 +77,11 @@ jobs:
           run: go test -v -race ./...
       - name: Collect coverage files
         id: coverages
-        if: fromJSON(step.config.outputs.json).noCover != true
+        if: fromJSON(steps.config.outputs.json).noCover != true
         shell: bash
         run: echo "files=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
       - name: Upload coverage to Codecov
-        if: fromJSON(step.config.outputs.json).noCover != true
+        if: fromJSON(steps.config.outputs.json).noCover != true
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           files: ${{ steps.coverages.outputs.files }}

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -36,14 +36,26 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
+      - id: args
+        env:
+          NO_SHUFFLE: ${{ fromJSON(steps.config.outputs.json).noShuffle }}
+          NO_COVER: ${{ fromJSON(steps.config.outputs.json).noCover }}
+        shell: bash
+        run: |
+          if [[ "$NO_SHUFFLE" != 'true' ]]; then
+            echo "shuffle=-shuffle=on" >> $GITHUB_OUTPUT
+          fi
+          if [[ "$NO_COVER" != 'true' ]]; then
+            # Use -coverpkg=./..., so that we include cross-package coverage.
+            # If package ./A imports ./B, and ./A's tests also cover ./B,
+            # this means ./B's coverage will be significantly higher than 0%.
+            echo "cover=-cover -coverprofile=module-coverage.txt -coverpkg=./..." >> $GITHUB_OUTPUT
+          fi
       - name: Run tests
         if: contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.2
         with:
-          # Use -coverpkg=./..., so that we include cross-package coverage.
-          # If package ./A imports ./B, and ./A's tests also cover ./B,
-          # this means ./B's coverage will be significantly higher than 0%.
-          run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
+          run: go test -v ${{ steps.args.outputs.shuffle }} ${{ steps.args.outputs.cover }} ./...
       - name: Run tests (32 bit)
         # can't run 32 bit tests on OSX.
         if: matrix.os != 'macos' &&
@@ -55,7 +67,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -v -shuffle=on ./...
+            go test -v ${{ steps.args.outputs.shuffle }} ./...
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow
         if: matrix.os == 'ubuntu' &&
@@ -64,10 +76,13 @@ jobs:
         with:
           run: go test -v -race ./...
       - name: Collect coverage files
+        id: coverages
+        if: fromJSON(step.config.outputs.json).noCover != true
         shell: bash
-        run: echo "COVERAGES=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_ENV
+        run: echo "files=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
       - name: Upload coverage to Codecov
+        if: fromJSON(step.config.outputs.json).noCover != true
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
-          files: '${{ env.COVERAGES }}'
+          files: ${{ steps.coverages.outputs.files }}
           env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}


### PR DESCRIPTION
Resolves #460

###### Description

By setting `GO*FLAGS` as top-level env variables, we allow them being overwritten in `go-test-setup` action. In particular, this will allow disabling coverage on one or all OSes.

###### Testing

- [x] https://github.com/filecoin-project/go-fil-commp-hashhash/pull/4