### PR TITLE
fix: push tag explicitly before publishing the release

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,11 +25,22 @@ jobs:
         uses: mukunku/tag-exists-action@9298fbcc409758ba624a0ae16b83df86637cb8ce # v1.2.0
         with:
           tag: ${{ steps.version.outputs.version }}
-      - name: Create release
+      - id: push
+        name: Create tag
         if: steps.version.outputs.version != '' && steps.tag.outputs.exists == 'false' && (
             github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
             contains(fromJSON(steps.labels.outputs.labels), 'release')
           )
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.version.outputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh api -X POST "repos/$REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA"
+          echo "conclusion=success" >> $GITHUB_OUTPUT
+      - name: Create release
+        if: steps.push.outputs.conclusion == 'success'
         uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
         with:
           draft: false


### PR DESCRIPTION
Resolves #481

This resolves a serious bug where releaser always creates tags from the default branch. This is because we started using GitHub Release publishing for tag creation with the latest major uCI release. GitHub Release publishing cannot be configured to create tags from branches other than default. That's why we should first create a tag, and only then publish a GitHub Release that references that tag.

This PR makes sure we create a tag for the correct SHA and only then publishes a GitHub Release for that tag.

###### Testing

I released `galargh/go-libp2p@v0.26.2` using the version of the workflow from this branch.
- release PR https://github.com/galargh/go-libp2p/pull/1
- release tag https://github.com/galargh/go-libp2p/tree/v0.26.2
- release branch https://github.com/galargh/go-libp2p/tree/release-v026
- GitHub Release https://github.com/galargh/go-libp2p/releases/tag/v0.26.2