### PR TITLE
fix: specify target for github release

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -120,6 +120,7 @@ jobs:
           draft: true
           tag_name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
+          target_commitish: ${{ github.event.pull_request.base.ref }}
       - id: message
         env:
           HEADER: |

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create release
         if: steps.version.outputs.version != '' && steps.tag.outputs.exists == 'false' && (
             github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
-            contains(fromJSON(steps.labels.outputs.labels), 'release')
+            contains(fromJSON(steps.labels.outputs.labels), 'release'))
         uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
         with:
           draft: false

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -46,3 +46,4 @@ jobs:
           draft: false
           tag_name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
+          target_commitish: ${{ github.sha }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,22 +25,10 @@ jobs:
         uses: mukunku/tag-exists-action@9298fbcc409758ba624a0ae16b83df86637cb8ce # v1.2.0
         with:
           tag: ${{ steps.version.outputs.version }}
-      - id: push
-        name: Create tag
+      - name: Create release
         if: steps.version.outputs.version != '' && steps.tag.outputs.exists == 'false' && (
             github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
             contains(fromJSON(steps.labels.outputs.labels), 'release')
-          )
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          TAG: ${{ steps.version.outputs.version }}
-          SHA: ${{ github.sha }}
-        run: |
-          gh api -X POST "repos/$REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA"
-          echo "conclusion=success" >> $GITHUB_OUTPUT
-      - name: Create release
-        if: steps.push.outputs.conclusion == 'success'
         uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
         with:
           draft: false


### PR DESCRIPTION
This should ensure we specify correct release notes. With this change, we can get rid of explicit tag creation because GitHub release publish will now know what sha to use to create a tag on publish (I didn't add it earlier because I didn't know this feature existed).

###### Testing

- Tag created with these workflows: https://github.com/galargh/go-libp2p/tree/v0.26.3
- Releaser workflow run: https://github.com/galargh/go-libp2p/actions/runs/4301371990/jobs/7498576592
- Release Check workflow run: https://github.com/galargh/go-libp2p/actions/runs/4301337709
- Release: https://github.com/galargh/go-libp2p/releases/tag/v0.26.3
- Release PR: https://github.com/galargh/go-libp2p/pull/3