### PR TITLE
Adds jobs for testing webkit and webkit-webworker

### DIFF
--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -93,6 +93,42 @@ jobs:
         with:
           flags: firefox-webworker
 
+  test-webkit:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [lts/*]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - run: npm run --if-present test:webkit
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          flags: webkit
+
+  test-webkit:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [lts/*]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - run: npm run --if-present test:webkit-webworker
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          flags: webkit-webworker
+
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
@@ -122,7 +158,7 @@ jobs:
           flags: electron-renderer
 
   release:
-    needs: [test-node, test-chrome, test-chrome-webworker, test-firefox, test-firefox-webworker, test-electron-main, test-electron-renderer]
+    needs: [test-node, test-chrome, test-chrome-webworker, test-firefox, test-firefox-webworker, test-webkit, test-webkit-webworker, test-electron-main, test-electron-renderer]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/${{{ github.default_branch }}}'
     steps:


### PR DESCRIPTION
To use in a project, declare npm scripts similar to `test:firefox` and `test:firefox-webworker`:

```js
// package.json
  "scripts": {
    // existing lines:
    "test:firefox": "aegir test -t browser -- --browser firefox",
    "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
    // add the lines below:
    "test:webkit": "aegir test -t browser -- --browser webkit",
    "test:webkit-webworker": "aegir test -t webworker -- --browser webkit"
  }
```

Runs webkit tests on MacOS X and Linux, not sure if both are necessary tbh.