### PR TITLE
feat: run go test/check on PR or push to default/protected branch

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -40,11 +40,16 @@ jobs:
       with:
         path: ${{ env.TEMPLATE_REPO_DIR }}
         ref: ${{ matrix.cfg.source_ref || github.ref }}
-    - name: determine GitHub default branch
+    - id: github
+      name: determine GitHub context
       working-directory: ${{ env.TARGET_REPO_DIR }}
+      env:
+        REPO: ${{ matrix.cfg.target}}
       run: |
-        default_branch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
-        echo "DEFAULT_BRANCH=$default_branch" >> $GITHUB_ENV
+        default_branch="$(git remote show origin | awk '/HEAD branch/ {print $NF}')"
+        protected_branches="$(gh api -X GET "/repos/$REPO/branches" -f protected=true | jq -c 'map(.name)')"
+        echo "default_branch=$default_branch" >> $GITHUB_OUTPUT
+        echo "protected_branches=$protected_branches" >> $GITHUB_OUTPUT
     - name: git config
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: |
@@ -105,9 +110,7 @@ jobs:
         CONTEXT: |
           {
             "config": ${{ toJSON(matrix.cfg) }},
-            "github": {
-              "default_branch": "${{ env.DEFAULT_BRANCH }}"
-            }
+            "github": ${{ toJSON(steps.github.outputs) }}
           }
         TEMPLATE_ENGINE: s#\$\{\{\{\s*(.*?)\s*\}\}\}#`jq -cjn 'env.CONTEXT | fromjson.$1'`#ge
       run: |

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -45,6 +45,7 @@ jobs:
       working-directory: ${{ env.TARGET_REPO_DIR }}
       env:
         REPO: ${{ matrix.cfg.target}}
+        GITHUB_TOKEN: ${{ secrets.WEB3_BOT_GITHUB_TOKEN }}
       run: |
         default_branch="$(git remote show origin | awk '/HEAD branch/ {print $NF}')"
         protected_branches="$(gh api -X GET "/repos/$REPO/branches" -f protected=true | jq -c 'map(.name)')"
@@ -110,7 +111,10 @@ jobs:
         CONTEXT: |
           {
             "config": ${{ toJSON(matrix.cfg) }},
-            "github": ${{ toJSON(steps.github.outputs) }}
+            "github": {
+              "default_branch": "${{ steps.github.outputs.default_branch }}",
+              "protected_branches": ${{ steps.github.outputs.protected_branches }}
+            }
           }
         TEMPLATE_ENGINE: s#\$\{\{\{\s*(.*?)\s*\}\}\}#`jq -cjn 'env.CONTEXT | fromjson.$1'`#ge
       run: |

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -116,7 +116,7 @@ jobs:
         CONTEXT: |
           {
             "config": ${{ toJSON(matrix.cfg) }},
-            "github": ${{ toJSON(steps.github.outputs.json) }}
+            "github": ${{ toJSON(fromJSON(steps.github.outputs.json)) }}
           }
         TEMPLATE_ENGINE: s#\$\{\{\{\s*\.?(.*?)\s*\}\}\}#`jq -cjn 'env.CONTEXT | fromjson | .$1'`#ge
       run: |

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -9,6 +9,10 @@ on:
         description: "List of repositories to deploy to"
         required: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   copy:
     runs-on: ubuntu-latest

--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -47,10 +47,15 @@ jobs:
         REPO: ${{ matrix.cfg.target}}
         GITHUB_TOKEN: ${{ secrets.WEB3_BOT_GITHUB_TOKEN }}
       run: |
+        eof="EOF$RANDOM"
         default_branch="$(git remote show origin | awk '/HEAD branch/ {print $NF}')"
         protected_branches="$(gh api -X GET "/repos/$REPO/branches" -f protected=true | jq -c 'map(.name)')"
-        echo "default_branch=$default_branch" >> $GITHUB_OUTPUT
-        echo "protected_branches=$protected_branches" >> $GITHUB_OUTPUT
+        echo "json<<$eof" >> $GITHUB_OUTPUT
+        echo '{' >> $GITHUB_OUTPUT
+        echo '"default_branch":"'"$default_branch"'",' >> $GITHUB_OUTPUT
+        echo '"protected_branches":'"$protected_branches" >> $GITHUB_OUTPUT
+        echo '}' >> $GITHUB_OUTPUT
+        echo "$eof" >> $GITHUB_OUTPUT
     - name: git config
       working-directory: ${{ env.TARGET_REPO_DIR }}
       run: |
@@ -111,12 +116,9 @@ jobs:
         CONTEXT: |
           {
             "config": ${{ toJSON(matrix.cfg) }},
-            "github": {
-              "default_branch": "${{ steps.github.outputs.default_branch }}",
-              "protected_branches": ${{ steps.github.outputs.protected_branches }}
-            }
+            "github": ${{ toJSON(steps.github.outputs.json) }}
           }
-        TEMPLATE_ENGINE: s#\$\{\{\{\s*(.*?)\s*\}\}\}#`jq -cjn 'env.CONTEXT | fromjson.$1'`#ge
+        TEMPLATE_ENGINE: s#\$\{\{\{\s*\.?(.*?)\s*\}\}\}#`jq -cjn 'env.CONTEXT | fromjson | .$1'`#ge
       run: |
         for f in $(jq -r '.[]' <<< "$FILES"); do
           echo -e "\nProcessing $f."

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: ${{{ github.protected_branches + .github.default_branch | unique }}}
 name: Go Checks
 
 jobs:

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: ${{{ github.protected_branches + .github.default_branch | unique }}}
+    branches: ${{{ github.protected_branches + [fromjson.github.default_branch] | unique }}}
 name: Go Checks
 
 jobs:

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: ${{{ github.protected_branches + [fromjson.github.default_branch] | unique }}}
+    branches: ${{{ .github.protected_branches + [.github.default_branch] | unique }}}
 name: Go Checks
 
 jobs:

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: ${{{ github.protected_branches + [fromjson.github.default_branch] | unique }}}
+    branches: ${{{ .github.protected_branches + [.github.default_branch] | unique }}}
 name: Go Test
 
 jobs:

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: ${{{ github.protected_branches + .github.default_branch | unique }}}
+    branches: ${{{ github.protected_branches + [fromjson.github.default_branch] | unique }}}
 name: Go Test
 
 jobs:

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: ${{{ github.protected_branches + .github.default_branch | unique }}}
 name: Go Test
 
 jobs:


### PR DESCRIPTION
This PR modifies the uCI templates in such a way that we don't duplicate as much work. In particular, `go-test` and `go-check` will keep running on all the pull requests BUT they will now run only on pushes to protected branches rather than on all the pushes.

###### Testing

- [x] https://github.com/protocol/.github-test-target/pull/55