### PR TITLE
feat: set concurrency on all the workflow templates

### DIFF
--- a/templates/.github/workflows/automerge.yml
+++ b/templates/.github/workflows/automerge.yml
@@ -1,6 +1,10 @@
 name: Automerge
 on: [ pull_request ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   automerge:
     uses: protocol/.github/.github/workflows/automerge.yml@master

--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -1,6 +1,10 @@
 on: [push, pull_request]
 name: Go Checks
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -1,6 +1,10 @@
 on: [push, pull_request]
 name: Go Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     strategy:

--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -5,6 +5,10 @@ on:
       - ${{{ github.default_branch }}}
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   check:

--- a/templates/.github/workflows/release-check.yml
+++ b/templates/.github/workflows/release-check.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     paths: [ 'version.json' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-check:
     uses: protocol/.github/.github/workflows/release-check.yml@master

--- a/templates/.github/workflows/releaser.yml
+++ b/templates/.github/workflows/releaser.yml
@@ -3,6 +3,10 @@ on:
   push:
     paths: [ 'version.json' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   releaser:
     uses: protocol/.github/.github/workflows/releaser.yml@master

--- a/templates/.github/workflows/tagpush.yml
+++ b/templates/.github/workflows/tagpush.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   releaser:
     uses: protocol/.github/.github/workflows/tagpush.yml@master


### PR DESCRIPTION
This PR introduces concurrency groups to all the workflows distributed via uCI. The concurrency groups work as follows:
- pull_request: if a new commit is pushed to the PR, any in-progress runs of the workflow for that PR are going to be cancelled
- push: no change, workflow runs will continue running until the end

###### Testing
- deployed the change to a test repo: https://github.com/protocol/.github-test-target/pull/54