### PR TITLE
feat: make -v and -shuffle configurable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ If your project cannot be built on one of the supported operating systems, you c
 }
 ```
 
+If you want to disable verbose logging or test shuffling, you can do so by setting `verbose` or `shuffle` to `false` in `.github/workflows/go-test-config.json`:
+```json
+{
+  "verbose": false,
+  "shuffle": false
+}
+```
+
 ## Technical Preview
 
 You can opt-in to receive early updates from the `next` branch in-between official Unified CI releases.

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ "ubuntu", "windows", "macos" ]
         go: ${{{ config.go.versions }}}
     env:
-      GOTESTFLAGS: -shuffle=on -cover -coverprofile=module-coverage.txt -coverpkg=./...
-      GO386FLAGS: -shuffle=on
-      GORACEFLAGS: -shuffle=on
+      GOTESTFLAGS: -cover -coverprofile=module-coverage.txt -coverpkg=./...
+      GO386FLAGS: ''
+      GORACEFLAGS: ''
     runs-on: ${{ fromJSON(vars[format('UCI_GO_TEST_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
@@ -27,6 +27,16 @@ jobs:
           submodules: recursive
       - id: config
         uses: protocol/.github/.github/actions/read-config@master
+      - if: toJSON(fromJSON(steps.config.outputs.json).shuffle) != 'false'
+        run: |
+          echo "GOTESTFLAGS=-shuffle=on $GOTESTFLAGS"
+          echo "GO386FLAGS=-shuffle=on $GO386FLAGS"
+          echo "GORACEFLAGS=-shuffle=on $GORACEFLAGS"
+      - if: toJSON(fromJSON(steps.config.outputs.json).verbose) != 'false'
+        run: |
+          echo "GOTESTFLAGS=-v $GOTESTFLAGS"
+          echo "GO386FLAGS=-v $GO386FLAGS"
+          echo "GORACEFLAGS=-v $GORACEFLAGS"
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
@@ -51,7 +61,7 @@ jobs:
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GOTESTFLAGS, env.GOFLAGS) }}
         with:
-          run: go test -v ./...
+          run: go test ./...
       - name: Run tests (32 bit)
         # can't run 32 bit tests on OSX.
         if: matrix.os != 'macos' &&
@@ -64,7 +74,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -v ./...
+            go test ./...
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow
         if: matrix.os == 'ubuntu' &&
@@ -73,7 +83,7 @@ jobs:
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GORACEFLAGS, env.GOFLAGS) }}
         with:
-          run: go test -v -race ./...
+          run: go test -race ./...
       - name: Collect coverage files
         id: coverages
         shell: bash


### PR DESCRIPTION
This is an alternative to https://github.com/protocol/.github/pull/513 which keeps the defaults as they were while allowing to opt-out of -v and -shuffle=on flags. 