### PR TITLE
chore: remove custom default_branch input from js-test-and-release

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -1,11 +1,6 @@
 name: test & maybe release
 on:
   workflow_call:
-    inputs:
-      default-branch:
-        description: 'The default branch of the repository'
-        required: true
-        type: string
 
 jobs:
 
@@ -165,7 +160,7 @@ jobs:
   release:
     needs: [test-node, test-chrome, test-chrome-webworker, test-firefox, test-firefox-webworker, test-webkit, test-webkit-webworker, test-electron-main, test-electron-renderer]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/${{ inputs.default-branch }}'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -16,5 +16,3 @@ concurrency:
 jobs:
   js-test-and-release:
     uses: protocol/.github/.github/workflows/js-test-and-release.yml@v1.0
-    with:
-      default-branch: ${{{ github.default_branch }}}


### PR DESCRIPTION
We can use `github.event.repository.default_branch` instead.