### PR TITLE
fix: copy already distributed shared workflows and actions to their old locations

### DIFF
--- a/.github/actions/read-config
+++ b/.github/actions/read-config
@@ -1,1 +1,0 @@
-../../shared/.github/actions/read-config

--- a/.github/actions/read-config/action.yml
+++ b/.github/actions/read-config/action.yml
@@ -1,0 +1,22 @@
+name: read config
+description: Reads workflow config
+
+outputs:
+  json:
+    description: JSON config
+    value: ${{ steps.config.outputs.json }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: config
+      run: |
+        eof="EOF$RANDOM"
+        path="${GITHUB_WORKFLOW_REF%.yml@*}"
+        path="./${path#*/*/}-config.json"
+        printf "json<<$eof\n%s\n$eof" "$(cat "$path" || echo '{}')" >> $GITHUB_OUTPUT
+      shell: bash
+    - env:
+        CONFIG: ${{ steps.config.outputs.json }}
+      run: echo "$CONFIG"
+      shell: bash

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,225 @@
+name: Release Checker
+on:
+  workflow_call:
+
+jobs:
+  releaser:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "EOF=EOF$RANDOM" >> $GITHUB_ENV
+        shell: bash
+      - uses: actions/checkout@v3
+      - id: go-mod
+        uses: protocol/.github/shared/.github/actions/read-go-mod@v1.0.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ fromJSON(steps.go-mod.outputs.json).Go }}.x
+      - id: version
+        name: Determine version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # If `version.json` file doesn't exists, `version` is `""` and `404` is printed on stderr.
+          # The step won't be marked as a failure though because the error happens in a subshell.
+          version="$(gh api -X GET "repos/$HEAD_FULL_NAME/contents/version.json" -f ref="$HEAD_SHA" --jq '.content' | base64 -d | jq -r '.version')"
+          echo "version=$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - id: tag
+        name: Check if the tag already exists
+        # Check if a git tag for the version (as read from version.json) exists
+        # If that is the case, we don't need to run the rest of the workflow.
+        if: steps.version.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git fetch origin --tags
+          status=0
+          git rev-list "$VERSION" &> /dev/null || status=$?
+          if [[ $status == 0 ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Install semver (node command line tool)
+        if: steps.tag.outputs.exists == 'false'
+        run: npm install -g "https://github.com/npm/node-semver#dc0fe202faaf19a545ce5eeab3480be84180a082" # v7.3.8
+      - name: Check version
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        # semver fails if the version is not valid (e.g. v0.1 would fail)
+        run: semver "$VERSION"
+      - id: prerelease
+        if: steps.tag.outputs.exists == 'false'
+        name: Check if this is a pre-release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        # semver -r fails if the version is not valid or if it is a pre-release (e.g v0.1 or v0.1.0-rc1 would fail)
+        run: echo "prerelease=$(semver -r "$VERSION" && echo false || echo true)" >> $GITHUB_OUTPUT
+      - id: prev
+        name: Determine version number to compare to
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.prerelease.outputs.prerelease }}
+        # We need to determine the version number we want to compare to,
+        # taking into account that this might be a (patch) release on a release branch.
+        # Example:
+        # Imagine a module that has releases for v0.1.0, v0.2.0, v0.3.0 and v0.3.0-rc1.
+        # When trying to cut a release v0.2.1, we need to base our comparisons on v0.2.0.
+        # When trying to cut a release v0.3.1 or v0.4.0, we need to base our comparisons on v0.3.0.
+        # When trying to cut a release v0.3.0-rc2, we need to base our comparisons on v0.3.0-rc1.
+        run: |
+          git fetch origin --tags
+          go install github.com/marten-seemann/semver-highest@fcdc98f8820ff0e6613c1bee071c096febd98dbf
+          vs=$(git tag | paste -sd , -)
+          if [[ ! -z "$vs" ]]; then
+            v=$(semver-highest -target "$VERSION" -versions "$vs" -prerelease="$PRERELEASE")
+            status=$?
+            if [[ $status != 0 ]]; then
+              echo $v
+              exit $status
+            fi
+            echo "version=$v" >> $GITHUB_OUTPUT
+          fi
+      - id: git-diff
+        name: run git diff on go.mod file(s)
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
+        run: |
+          # First get the diff for the go.mod file in the root directory...
+          output=$(git diff "$PREV_VERSION..HEAD" -- './go.mod')
+          # ... then get the diff for all go.mod files in subdirectories.
+          # Note that this command also finds go.mod files more than one level deep in the directory structure.
+          output+=$(git diff "$PREV_VERSION..HEAD" -- '*/go.mod')
+          if [[ -z "$output" ]]; then
+            output="(empty)"
+          fi
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
+      - id: gorelease
+        name: Run gorelease
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
+        # see https://github.com/golang/exp/commits/master/cmd/gorelease
+        run: |
+          go mod download
+          go install golang.org/x/exp/cmd/gorelease@f062dba9d201f5ec084d25785efec05637818c00 # https://cs.opensource.google/go/x/exp/+/f062dba9d201f5ec084d25785efec05637818c00
+          output=$((gorelease -base "$PREV_VERSION") 2>&1 || true)
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
+      - id: gocompat
+        name: Check Compatibility
+        if: steps.tag.outputs.exists == 'false' && steps.prev.outputs.version != ''
+        env:
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
+        run: |
+          go install github.com/smola/gocompat/cmd/gocompat@8498b97a44792a3a6063c47014726baa63e2e669 # v0.3.0
+          output=$(gocompat compare --go1compat --git-refs="$PREV_VERSION..HEAD" ./... || true)
+          if [[ -z "$output" ]]; then
+            output="(empty)"
+          fi
+          printf "output<<$EOF\n%s\n$EOF" "$output" >> $GITHUB_OUTPUT
+      - id: release
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
+        with:
+          draft: true
+          tag_name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          target_commitish: ${{ github.event.pull_request.base.ref }}
+      - id: message
+        env:
+          HEADER: |
+            Suggested version: `${{ steps.version.outputs.version }}`
+          BODY: |
+            Comparing to: [${{ steps.prev.outputs.version }}](${{ github.event.pull_request.base.repo.html_url }}/releases/tag/${{ steps.prev.outputs.version }}) ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ steps.prev.outputs.version }}..${{ github.event.pull_request.head.label }}))
+
+            Changes in `go.mod` file(s):
+            ```diff
+            ${{ steps.git-diff.outputs.output }}
+            ```
+
+            `gorelease` says:
+            ```
+            ${{ steps.gorelease.outputs.output }}
+            ```
+
+            `gocompat` says:
+            ```
+            ${{ steps.gocompat.outputs.output }}
+            ```
+
+          BODY_ALT: |
+            This is the first release of this module.
+
+          RELEASE_BRANCH_NOTICE: |
+            ## Cutting a Release (when not on `${{ github.event.repository.default_branch }}`)
+
+            This PR is targeting `${{ github.base_ref }}`, which is not the default branch.
+            If you wish to cut a release once this PR is merged, please add the `release` label to this PR.
+
+          DIFF_NOTICE: |
+            ## Cutting a Release (and modifying non-markdown files)
+
+            This PR is modifying both `version.json` and non-markdown files.
+            The Release Checker is not able to analyse files that are not checked in to `${{ github.base_ref }}`. This might cause the above analysis to be inaccurate.
+            Please consider performing all the code changes in a separate PR before cutting the release.
+
+          RELEASE_NOTICE: |
+            ## Automatically created GitHub Release
+
+            A [draft GitHub Release](${{ steps.release.outputs.url }}) has been created.
+            It is going to be published when this PR is merged.
+            You can modify its' body to include any release notes you wish to include with the release.
+
+          RELEASE_NOTICE_ALT: |
+            ## Automatically created GitHub Release
+
+            Pre-creating GitHub Releases on release PRs initiated from forks is not supported.
+            If you wish to prepare release notes yourself, you should create a draft GitHub Release for tag `${{ steps.version.outputs.version }}` manually.
+            The draft GitHub Release is going to be published when this PR is merged.
+            If you choose not to create a draft GitHub Release, a published GitHub Released is going to be created when this PR is merged.
+
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+          HEAD_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PREV_VERSION: ${{ steps.prev.outputs.version }}
+        run: |
+          echo "output<<$EOF" >> $GITHUB_OUTPUT
+
+          echo "$HEADER" >> $GITHUB_OUTPUT
+
+          if [[ "$PREV_VERSION" != "" ]]; then
+            echo "$BODY" >> $GITHUB_OUTPUT
+          else
+            echo "$BODY_ALT" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$DEFAULT_BRANCH" != "$BASE_REF" ]]; then
+            echo "$RELEASE_BRANCH_NOTICE" >> $GITHUB_OUTPUT
+          fi
+
+          diff="$(gh api -X GET "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_LABEL" --jq '.files | map(.filename) | map(select(test("^(version\\.json|.*\\.md)$") | not)) | .[]')"
+          if [[ "$diff" != "" ]]; then
+            echo "$DIFF_NOTICE" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$GITHUB_REPOSITORY" == "$HEAD_FULL_NAME" ]]; then
+            echo "$RELEASE_NOTICE" >> $GITHUB_OUTPUT
+          else
+            echo "$RELEASE_NOTICE_ALT" >> $GITHUB_OUTPUT
+          fi
+
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Post message on PR
+        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # v2.3.1
+        if: steps.tag.outputs.exists == 'false'
+        with:
+          header: release-check
+          recreate: true
+          message: ${{ steps.message.outputs.output }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,1 +1,0 @@
-../../shared/.github/workflows/release-check.yml

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,1 +1,0 @@
-../../shared/.github/workflows/releaser.yml

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,58 @@
+name: Releaser
+on: [ workflow_call ]
+
+jobs:
+  releaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: version
+        name: Determine version
+        run: echo "version=$(jq -r .version version.json)" >> $GITHUB_OUTPUT
+      - id: labels
+        name: Determine PR labels if this commit is a merged PR (if we're not on a default branch)
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: echo "labels=$(gh api -X GET "$ENDPOINT" --jq "$SELECTOR" -f sort="$SORT" -f direction="$DIRECTION" -f state="$STATE")" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ENDPOINT: repos/${{ github.repository }}/pulls
+          SELECTOR: map(select(.merge_commit_sha == "${{ github.sha }}")) | .[0].labels // [] | map(.name)
+          SORT: updated
+          DIRECTION: desc
+          STATE: closed
+      - id: tag
+        name: Check if tag already exists
+        if: steps.version.outputs.version != ''
+        uses: mukunku/tag-exists-action@9298fbcc409758ba624a0ae16b83df86637cb8ce # v1.2.0
+        with:
+          tag: ${{ steps.version.outputs.version }}
+      - id: release
+        name: Create release
+        if: steps.version.outputs.version != '' && steps.tag.outputs.exists == 'false' && (
+            github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+            contains(fromJSON(steps.labels.outputs.labels), 'release'))
+        uses: galargh/action-gh-release@25b3878b4c346655a4d3d9bea8b76638f64743cf # https://github.com/softprops/action-gh-release/pull/316
+        with:
+          draft: false
+          tag_name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          target_commitish: ${{ github.sha }}
+      - name: Create release.json
+        if: steps.release.outputs.id != ''
+        env:
+          RELEASE: |
+            {
+              "draft": false,
+              "version": "${{ steps.version.outputs.version }}",
+              "url": "${{ steps.release.outputs.url }}",
+              "id": "${{ steps.release.outputs.id }}",
+              "upload_url": "${{ steps.release.outputs.upload_url }}",
+              "assets": ${{ steps.release.outputs.assets }}
+            }
+        run: jq . <<< "$RELEASE" > release.json
+      - name: Upload release.json
+        if: steps.release.outputs.id != ''
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: release.json

--- a/.github/workflows/tagpush.yml
+++ b/.github/workflows/tagpush.yml
@@ -1,0 +1,49 @@
+name: Manual Release Nag
+on: [ workflow_call ]
+
+env:
+  ISSUE_TITLE: "manual release created (%tagname%)"
+  ISSUE_ASSIGNEE: "%pusher%"
+  ISSUE_BODY: |
+    @{{ env.PUSHER }} just pushed a release tag: {{ env.TAGNAME }}.
+    Please manually verify validity (using [\`gorelease\`](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease)), and update \`version.json\` to reflect the manually released version, if necessary.
+    In the future, please use the [automated process](https://github.com/protocol/.github/blob/master/VERSIONING.md).
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: All
+    env:
+      TAGNAME: ""
+    steps:
+      - uses: actions/checkout@v3
+      - run: cat "$GITHUB_EVENT_PATH" | jq -M .
+      - name: extract tag name
+        run: |
+          tagname=$(echo "$GITHUB_REF" | sed "s/refs\/tags\///")
+          echo $tagname
+          echo "TAGNAME=$tagname" >> $GITHUB_ENV
+      - name: create issue template file
+        if: github.event.pusher.name != 'web3-bot'
+        env:
+          PUSHER: ${{ github.event.pusher.name }}
+        run: |
+          echo "---" >> .github/workflows/tagpush.md
+          echo "title: $ISSUE_TITLE" | sed "s/%tagname%/$TAGNAME/" >> .github/workflows/tagpush.md
+          echo "assignees: $ISSUE_ASSIGNEE" | sed "s/%pusher%/$PUSHER/" >> .github/workflows/tagpush.md
+          echo "---" >> .github/workflows/tagpush.md
+          cat <<EOF >> .github/workflows/tagpush.md
+          $ISSUE_BODY
+          EOF
+      - run: cat .github/workflows/tagpush.md
+      - name: create an issue
+        if: github.event.pusher.name != 'web3-bot'
+        uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd # v2.9.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUSHER: ${{ github.event.pusher.name }}
+        with:
+          filename: .github/workflows/tagpush.md
+      - name: fail build if push wasn't done by web3-bot
+        if: github.event.pusher.name != 'web3-bot'
+        run: exit 1

--- a/.github/workflows/tagpush.yml
+++ b/.github/workflows/tagpush.yml
@@ -1,1 +1,0 @@
-../../shared/.github/workflows/tagpush.yml

--- a/scripts/copy-legacy-workflows-and-actions.sh
+++ b/scripts/copy-legacy-workflows-and-actions.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# array of strings with paths to legacy items to copy
+declare -a legacy_items=(
+  ".github/actions/read-config"
+  ".github/workflows/release-check.yml"
+  ".github/workflows/releaser.yml"
+  ".github/workflows/tagpush.yml"
+)
+
+# loop through the array
+for item in "${legacy_items[@]}"; do
+  # if the item exists
+  if [ -e "$item" ]; then
+    # delete it
+    rm -rf "$item"
+  fi
+  # copy the item from the shared folder
+  cp -r "shared/$item" "$item"
+done


### PR DESCRIPTION
This is a follow-up to https://github.com/protocol/.github/pull/542. Unfortunately, GHA doesn't understand symlinks :( I still think it's worth pursuing the restructure because it brings more clarity to the unified CI repo.