### PR TITLE
feat: by default perform dependabot-like updates only

### DIFF
--- a/scripts/copy-templates.sh
+++ b/scripts/copy-templates.sh
@@ -2,35 +2,65 @@
 
 set -euo pipefail -o nounset
 
+force="$(jq -r '.force' <<< "$CONTEXT")"
+
+root="$(pwd)"
+
+pushd "$REPO" > /dev/null
+
 for f in $(jq -r '.config.files[]' <<< "$CONTEXT"); do
-  echo -e "\nProcessing $f."
-  # add DO NOT EDIT header
-  tmp=$(mktemp)
-  cat protocol/.github/templates/header.yml protocol/.github/templates/$f > $tmp
-  # render template
-  ./protocol/.github/scripts/render-template.sh "$tmp" "$CONTEXT" "$tmp"
-  # create commit, if necessary
-  commit_msg=""
-  if [[ ! -f "$REPO/$f" ]]; then
-    echo "First deployment.\n"
-    commit_msg="chore: add $f"
-  elif [[ "$f" == "version.json" ]]; then
-    echo "Version file. Skipping."
+  if [[ -f "$f" && "$force" != "true" ]]; then
+    echo "$f already exists. Skipping."
     continue
-  else
-    status=$(cmp --silent $REPO/$f $tmp; echo $?)
-    if [[ $status -ne 0 ]]; then
-      echo "Update needed."
-      commit_msg="chore: update $f"
-    else
-      echo "File identical. Skipping."
+  fi
+
+  echo "Rendering template..."
+  $root/protocol/.github/scripts/render-template.sh "$root/protocol/.github/templates/$f" "$CONTEXT" "$f"
+
+  git add "$f"
+done
+
+if [[ "$force" != "true" ]]; then
+  # https://gist.github.com/mattt/e09e1ecd76d5573e0517a7622009f06f
+  gh gist view --raw e09e1ecd76d5573e0517a7622009f06f | bash
+
+  tmp="$(mktemp)"
+
+  dependabot update github_actions  "$REPO" --local "$REPO" --output "$tmp"
+
+  branch="$(git branch --show-current)"
+  sha="$(git rev-parse HEAD)"
+
+  for pr in $(yq -c '.output | map(select(.type == "create_pull_request")) | .[]' "$tmp"); do
+    title="$(jq -r '.pr-title' <<< "$pr")"
+    git checkout -b "$title" "$branch"
+    for f in $(jq -r '.updated-dependency-files[]' <<< "$pr"); do
+      jq -r '.content' <<< "$f" > "$REPO/$(jq -r '.name' <<< "$f")"
+    done
+    git add .
+    git commit -m "$(jq -r '.commit-message' <<< "$pr")"
+    git checout "$branch"
+    git merge "$title" --strategy-option theirs
+  done
+
+  git reset "$sha"
+
+  for f in $(jq -r '.config.files[]' <<< "$CONTEXT"); do
+    if [[ ! -f "$REPO/$f" ]]; then
+      echo "$f does not exist. Skipping."
       continue
     fi
-  fi
-  mkdir -p "$REPO/$(dirname $f)"
-  mv $tmp $REPO/$f
-  pushd $REPO > /dev/null
-  git add $f
-  git commit -m "$commit_msg"
-  popd > /dev/null
-done
+
+    git add "$f"
+  done
+fi
+
+if ! git diff-index --quiet HEAD; then
+  git commit -m "chore: add/update $f"
+fi
+
+if [[ "$force" != "true" ]]; then
+  git reset --hard
+fi
+
+popd > /dev/null

--- a/shared/.github/workflows/process.yml
+++ b/shared/.github/workflows/process.yml
@@ -93,7 +93,7 @@ jobs:
         OVERRIDE: ${{ fromJSON(github.event.inputs.override)[fromJSON(steps.github.outputs.json).languages[0]] || github.event.inputs.override || '{}' }}
       run: |
         if [[ -f uci.yml ]]; then
-          echo "json=$(jq -c --argjson defaults "$DEFAULTS" --argjson override "$OVERRIDE" '$defaults + . + $override' uci.yml)" >> $GITHUB_OUTPUT
+          echo "json=$(yq -c --argjson defaults "$DEFAULTS" --argjson override "$OVERRIDE" '$defaults + . + $override' uci.yml)" >> $GITHUB_OUTPUT
         else
           echo "json=$(jq -c --argjson defaults "$DEFAULTS" --argjson override "$OVERRIDE" -n '$defaults + $override')" >> $GITHUB_OUTPUT
     - name: Prepare ${{ matrix.repository }} for deployment

--- a/templates/header.yml
+++ b/templates/header.yml
@@ -1,3 +1,0 @@
-# File managed by web3-bot. DO NOT EDIT.
-# See https://github.com/protocol/.github/ for details.
-


### PR DESCRIPTION
With this change, Unified CI will start defaulting to performing dependabot-like updates only. I.e. it will only try to update dependency versions but the rest of the workflows will stay intact if they already exist. We'll be able to opt-out of this behaviour by adding `force: true` flag to the `uci.yml`.

If dependabot is configured to update GitHub Actions in a repository, we're going to skip web3-bot updates.