### PR TITLE
Enable unified CI for `boostly` and `telefil` in filecoin-shipyard

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -80,7 +80,13 @@
       "target": "filecoin-saturn/caboose"
     },
     {
+      "target": "filecoin-shipyard/boostly"
+    },
+    {
       "target": "filecoin-shipyard/js-lotus-client-schema"
+    },
+    {
+      "target": "filecoin-shipyard/telefil"
     },
     {
       "target": "ipfs-shipyard/dnslink-dnsimple"


### PR DESCRIPTION
Permission to web3-bot has already been granted. Add the repos to the unified CI build.