### PR TITLE
Add filecoin-shipyard/jiffy to Golang unified CI

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -83,6 +83,9 @@
       "target": "filecoin-shipyard/boostly"
     },
     {
+      "target": "filecoin-shipyard/jiffy"
+    },
+    {
       "target": "filecoin-shipyard/js-lotus-client-schema"
     },
     {


### PR DESCRIPTION
Necessary permissions have already been granted to @web3-bot.

See: https://github.com/filecoin-shipyard/jiffy