### PR TITLE
Add ipfs/go-block-format back to uci

### DIFF
--- a/configs/go.json
+++ b/configs/go.json
@@ -138,6 +138,9 @@
       "target": "ipfs/go-bitfield"
     },
     {
+      "target": "ipfs/go-block-format"
+    },
+    {
       "target": "ipfs/go-bs-sqlite3"
     },
     {


### PR DESCRIPTION
was deprecated/archived at one point, but back from the dead and behind on uci now